### PR TITLE
Params with array values were not parsing into the format that rack expects

### DIFF
--- a/lib/typhoeus/request.rb
+++ b/lib/typhoeus/request.rb
@@ -95,7 +95,7 @@ module Typhoeus
           value.keys.collect {|sk| Rack::Utils.escape("#{k}[#{sk}]") + "=" + Rack::Utils.escape(value[sk].to_s)}
         elsif value.is_a? Array
           key = Rack::Utils.escape(k.to_s)
-          value.collect { |v| "#{key}=#{Rack::Utils.escape(v.to_s)}" }.join('&')
+          value.collect { |v| "#{key}[]=#{Rack::Utils.escape(v.to_s)}" }.join('&')
         else
           "#{Rack::Utils.escape(k.to_s)}=#{Rack::Utils.escape(params[k].to_s)}"
         end

--- a/spec/typhoeus/request_spec.rb
+++ b/spec/typhoeus/request_spec.rb
@@ -24,6 +24,14 @@ describe Typhoeus::Request do
                                       })
       request.params_string.should == "a=jlk&b=fdsa&c=789"
     end
+
+    it "should translate params with values that are arrays to the proper format" do
+      request = Typhoeus::Request.new('http://google.com',
+                                      :params => {
+                                        :a => ['789','2434']
+                                      })
+      request.params_string.should == "a[]=789&a[]=2434"
+    end
   end
 
   describe "quick request methods" do
@@ -160,9 +168,9 @@ describe Typhoeus::Request do
     request.call_handlers
     good.should be_true
   end
-  
+
   describe "authentication" do
-    
+
     it "should allow to set username and password" do
       auth = { :username => 'foo', :password => 'bar' }
       e = Typhoeus::Request.get(


### PR DESCRIPTION
Check out the diff, let me know if you did that intentionally or not, but this works a lot better with my apps.  The other option is to use a string key of "key[]" in your request.
