### PR TITLE
Trivial README syntax: Accept, not Accepts

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -51,7 +51,7 @@ require 'json'
 request = Typhoeus::Request.new("http://www.pauldix.net",
                                 :body          => "this is a request body",
                                 :method        => :post,
-                                :headers       => {:Accepts => "text/html"},
+                                :headers       => {:Accept => "text/html"},
                                 :timeout       => 100, # milliseconds
                                 :cache_timeout => 60, # seconds
                                 :params        => {:field1 => "a field"})


### PR DESCRIPTION
Hi Paul

Trivial change, the README shows the HTTP Accept Header as "Accepts" with an "s".
I believe the RFC lists only "Accept"
