### PR TITLE
Minor documentation update in Advanced Authentication section

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -264,7 +264,7 @@ There's also an easy way to perform any kind of authentication via the quick req
 e = Typhoeus::Request.get("http://example.com",
   :username => 'username',
   :password => 'password',
-  :method => :ntlm)
+  :auth_method => :ntlm)
 </pre>
 
 All methods listed above is available in a shorter form - :basic, :digest, :gssnegotiate, :ntlm, :digest_ie, :auto.


### PR DESCRIPTION
I noticed that the README in the Advanced Authentication section notes the wrong parameter name for the authentication method in the quick interface.

I'm new to git, so not sure if this is the right way to make a fix as simple as this...
