### PR TITLE
Ignore hosts option

### DIFF
--- a/lib/typhoeus/request.rb
+++ b/lib/typhoeus/request.rb
@@ -84,8 +84,10 @@ module Typhoeus
       @handled_response = nil
     end
 
+    LOCALHOST_ALIASES = %w[ localhost 127.0.0.1 0.0.0.0 ]
+
     def localhost?
-      %(localhost 127.0.0.1 0.0.0.0).include?(@parsed_uri.host)
+      LOCALHOST_ALIASES.include?(@parsed_uri.host)
     end
 
     def host
@@ -96,6 +98,10 @@ module Typhoeus
         query_string_location = @url.index('?')
         return query_string_location ? @url.slice(0, query_string_location) : @url
       end
+    end
+
+    def host_domain
+      @parsed_uri.host
     end
 
     def headers

--- a/spec/typhoeus/hydra_spec.rb
+++ b/spec/typhoeus/hydra_spec.rb
@@ -430,6 +430,33 @@ describe Typhoeus::Hydra::ConnectOptions do
     end
   end
 
+  describe "#ignore_hosts" do
+    context 'when allow_net_connect is set to false' do
+      before(:each) do
+        @klass.ignore_localhost = false
+        @klass.allow_net_connect = false
+      end
+
+      Typhoeus::Request::LOCALHOST_ALIASES.each do |disallowed_host|
+        ignore_hosts = Typhoeus::Request::LOCALHOST_ALIASES - [disallowed_host]
+
+        context "when set to #{ignore_hosts.join(' and ')}" do
+          before(:each) { @klass.ignore_hosts = ignore_hosts }
+
+          it "does not allow a request to #{disallowed_host}" do
+            expect { hydra.queue(request_for(disallowed_host)) }.to raise_error(Typhoeus::Hydra::NetConnectNotAllowedError)
+          end
+
+          ignore_hosts.each do |host|
+            it "allows a request to #{host}" do
+              expect { hydra.queue(request_for(host)) }.to_not raise_error
+            end
+          end
+        end
+      end
+    end
+  end
+
   describe "#allow_net_connect" do
     it "should be settable" do
       @klass.allow_net_connect = true


### PR DESCRIPTION
For VCR, I've [received a request](https://github.com/myronmarston/vcr/issues#issue/30) to allow users to whitelist any host (not just the localhost ones).

Typhoeus doesn't currently support this, so I added it, in the form of an ignore_hosts option.

BTW, the `Typhoeus::Request#host` surprised me a bit--I expected it to be the raw host (i.e. `example.com`) but it included the protocol and port as well.  I added a new method (`#host_domain`) for just the host, but you may want to rename these (well, hopefully deprecate them, and provide new versions that are not so confusing) so there's less confusion at some point.
