### PR TITLE
Add Tempfile support to typhoeus -- Posting Tempfile's doesn't work

### DIFF
--- a/lib/typhoeus/utils.rb
+++ b/lib/typhoeus/utils.rb
@@ -1,3 +1,5 @@
+require 'tempfile'
+
 module Typhoeus
   module Utils
     # Taken from Rack::Utils, 1.2.1 to remove Rack dependency.
@@ -22,7 +24,7 @@ module Typhoeus
           hash[key].each do |v|
             result[:params] << [array_key, v.to_s]
           end
-        when File
+        when File, Tempfile
           filename = File.basename(hash[key].path)
           types = MIME::Types.type_for(filename)
           result[:files] << [

--- a/spec/typhoeus/form_spec.rb
+++ b/spec/typhoeus/form_spec.rb
@@ -62,6 +62,16 @@ describe Typhoeus::Form do
         form.should_receive(:formadd_file).with("text_file", "placeholder.txt", "text/plain", anything)
         form.process!
       end
+
+      it "should handle tempfiles (file subclasses)" do
+        tempfile = Tempfile.new('placeholder_temp')
+        form = Typhoeus::Form.new(
+          :file => tempfile
+        )
+        form.should_receive(:formadd_file).with("file", File.basename(tempfile.path), "application/octet-stream", anything)
+        form.process!
+      end
+
       it "should default to 'application/octet-stream' if no content type can be determined" do
         pending
         form = Typhoeus::Form.new(


### PR DESCRIPTION
Currently the typhoeus' file support doesn't work for Tempfiles. This pull request adds support for them. 

A couple notes:
- Tempfile.new('foo').is_a?(File) == false, so value.is_a?(File) doesn't work (how I'd of preferred the implementation to be)
- this adds a require 'tempfile' to the api, tempfile's in the stdlib, so I don't feel bad about that, but we could do some const_defined? magic if that wasn't desired
