### PR TITLE
Typhoeus should not add brackets to array query params by default

### DIFF
--- a/lib/typhoeus/utils.rb
+++ b/lib/typhoeus/utils.rb
@@ -20,9 +20,8 @@ module Typhoeus
         when Hash
           traverse_params_hash(hash[key], result, new_key)
         when Array
-          array_key = "#{new_key}[]"
           hash[key].each do |v|
-            result[:params] << [array_key, v.to_s]
+            result[:params] << [new_key, v.to_s]
           end
         when File, Tempfile
           filename = File.basename(hash[key].path)

--- a/spec/typhoeus/request_spec.rb
+++ b/spec/typhoeus/request_spec.rb
@@ -74,6 +74,14 @@ describe Typhoeus::Request do
                                       :params => {
                                         :a => ['789','2434']
                                       })
+      request.params_string.should == "a=789&a=2434"
+    end
+    
+    it "should allow the newer bracket notation for array params" do
+      request = Typhoeus::Request.new('http://google.com',
+                                      :params => {
+                                        "a[]" => ['789','2434']
+                                      })
       request.params_string.should == "a%5B%5D=789&a%5B%5D=2434"
     end
 


### PR DESCRIPTION
See https://groups.google.com/forum/#!topic/typhoeus/lKXr88ImrN4 for a short discussion.

I modified the code so that `:params => { :a => [1, 2]}` will be encoded as `a=1&a=2`. If users want the bracket notation, they can just do `:params => { "a[]" => [1, 2]}` instead.
