### PR TITLE
fixed problems related to put requests with empty bodies

### DIFF
--- a/lib/typhoeus/easy.rb
+++ b/lib/typhoeus/easy.rb
@@ -179,9 +179,7 @@ module Typhoeus
     def request_body=(request_body)
       @request_body = request_body
       if @method == :put
-        easy_set_request_body(@request_body)
-        headers["Transfer-Encoding"] = ""
-        headers["Expect"] = ""
+        easy_set_request_body(@request_body.to_s)
       else
         self.post_data = request_body
       end
@@ -209,7 +207,7 @@ module Typhoeus
         self.post_data = ""
       elsif method == :put
         set_option(OPTION_VALUES[:CURLOPT_UPLOAD], 1)
-        self.request_body = "" unless @request_body
+        self.request_body = @request_body.to_s
       elsif method == :head
         set_option(OPTION_VALUES[:CURLOPT_NOBODY], 1)
       else
@@ -350,6 +348,7 @@ module Typhoeus
       @response_code = 0
       @response_header = ""
       @response_body = ""
+      @request_body = ""
       easy_reset()
     end
 

--- a/spec/typhoeus/easy_spec.rb
+++ b/spec/typhoeus/easy_spec.rb
@@ -215,6 +215,24 @@ describe Typhoeus::Easy do
       easy.response_code.should == 200
       easy.response_body.should include("this is a body!")
     end
+
+    it "should be able perform put with empty bodies on the same easy handle" do
+      easy = Typhoeus::Easy.new
+      easy.url    = "http://localhost:3002"
+      easy.method = :put
+      easy.perform
+      easy.response_code.should == 200
+      JSON.parse(easy.response_body)["REQUEST_METHOD"].should == "PUT"
+
+      easy.reset
+
+      easy.url    = "http://localhost:3002"
+      easy.method = :put
+      easy.perform
+      easy.response_code.should == 200
+      JSON.parse(easy.response_body)["REQUEST_METHOD"].should == "PUT"
+    end
+
   end
   
   describe "post" do


### PR DESCRIPTION
When reusing easy handles to send put requests, libcurl was switching to "Transfer-Encoding: chunked", and did not set a proper Content-Length header.

This behavior was caused by not properly resetting easy handles.

I've fixed this problem and added a test for the proper behavior.

The test cuses the spec suite to hang, if the fix isn't applied.

Could you please merge and release a new gem?

Thx a lot.
