### PR TITLE
Typhoeus::Request was modifying the passed in options

### DIFF
--- a/lib/typhoeus/request.rb
+++ b/lib/typhoeus/request.rb
@@ -43,14 +43,16 @@ module Typhoeus
     # ** +:password
     # ** +:auth_method
     #
-    def initialize(url, options = {})
+    def initialize(url, opts = {})
+      options = opts.dup  # do not modify passed-in options
       @method           = options[:method] || :get
       @params           = options[:params]
       @body             = options[:body]
       @timeout          = options[:timeout]
       @connect_timeout  = options[:connect_timeout]
       @interface        = options[:interface]
-      @headers          = options[:headers] || {}
+      # the dup above only does a shallow copy, so we have to dup again for 'headers'
+      @headers          = options[:headers] ? options[:headers].dup : {} 
       @user_agent       = options[:user_agent] || Typhoeus::USER_AGENT
       @cache_timeout    = options[:cache_timeout]
       @follow_location  = options[:follow_location]

--- a/spec/typhoeus/request_spec.rb
+++ b/spec/typhoeus/request_spec.rb
@@ -132,6 +132,12 @@ describe Typhoeus::Request do
     Typhoeus::Request.new("http://localhost:3000").host.should == "http://localhost:3000"
   end
 
+  it "does not modify the passed options" do
+    options = {:headers => {"some header" => "some header value"}, :user_agent => "some agent"}
+    Typhoeus::Request.get("http://localhost:3000", options)
+    options.should == {:headers => {"some header" => "some header value"}, :user_agent => "some agent"}
+  end
+
   it "takes method as an option" do
     Typhoeus::Request.new("http://localhost:3000", :method => :get).method.should == :get
   end
@@ -139,7 +145,7 @@ describe Typhoeus::Request do
   it "takes headers as an option" do
     headers = {:foo => :bar}
     request = Typhoeus::Request.new("http://localhost:3000", :headers => headers)
-    request.headers.should == headers
+    request.headers.should include(headers)
   end
 
   it "takes params as an option and adds them to the url" do


### PR DESCRIPTION
``` ruby
options = { :user_agent => "some agent", :headers => {"some header" => "some header value"},}
Typhoeus::Request.get("http://localhost:3000", options)
options # => {:user_agent=>"some agent", :headers=>{"User-Agent"=>"AgentBlue", "some header"=>"some header value"}}
```

I think in general options shouldn't be modified without some sort of warning, so I added a opts.dup. However, that only does a shallow copy so for an embedded hash like the 'headers' option you have to do a second dup.
