### PR TITLE
Use the passed in escape value, not just always escape.

### DIFF
--- a/lib/typhoeus/utils.rb
+++ b/lib/typhoeus/utils.rb
@@ -43,7 +43,7 @@ module Typhoeus
 
     def traversal_to_param_string(traversal, escape = true)
       traversal[:params].collect { |param|
-        "#{Typhoeus::Utils.escape(param[0])}=#{Typhoeus::Utils.escape(param[1])}"
+        escape ? "#{Typhoeus::Utils.escape(param[0])}=#{Typhoeus::Utils.escape(param[1])}" : "#{param[0]}=#{param[1]}"
       }.join('&')
     end
     module_function :traversal_to_param_string

--- a/spec/typhoeus/easy_spec.rb
+++ b/spec/typhoeus/easy_spec.rb
@@ -191,7 +191,7 @@ describe Typhoeus::Easy do
         :username => ['dbalatero', 'dbalatero2']
       }
       
-      easy.url.should =~ /\?.*username%5B%5D=dbalatero&username%5B%5D=dbalatero2/
+      easy.url.should =~ /\?.*foo=bar&username\[\]=dbalatero&username\[\]=dbalatero2/
     end
   end
 
@@ -275,7 +275,7 @@ describe Typhoeus::Easy do
 
       request = JSON.parse(easy.response_body)
       request['CONTENT_TYPE'].should == 'application/x-www-form-urlencoded' 
-      request['rack.request.form_vars'].should == 'a=b&c=d&e%5Bf%5D%5Bg%5D=h'
+      request['rack.request.form_vars'].should == 'a=b&c=d&e[f][g]=h'
     end
 
     it "should handle a file upload, as multipart" do

--- a/spec/typhoeus/form_spec.rb
+++ b/spec/typhoeus/form_spec.rb
@@ -89,7 +89,7 @@ describe Typhoeus::Form do
         :name => "John Smith",
         :age => "29"
       })
-      form.to_s.should == "age=29&name=John+Smith"
+      form.to_s.should == "age=29&name=John Smith"
     end
 
     it "should handle params that are a hash" do
@@ -102,7 +102,7 @@ describe Typhoeus::Form do
         :name => "John Smith",
         :age => "29"
       })
-      form.to_s.should == "age=29&attributes%5Beyes%5D=brown&attributes%5Bhair%5D=green&attributes%5Bteeth%5D=white&name=John+Smith"
+      form.to_s.should == "age=29&attributes[eyes]=brown&attributes[hair]=green&attributes[teeth]=white&name=John Smith"
     end
 
     it "should params that have mutliple values" do
@@ -111,7 +111,7 @@ describe Typhoeus::Form do
         :name => "John Smith",
         :age => "29"
       })
-      form.to_s.should == "age=29&colors%5B%5D=brown&colors%5B%5D=green&colors%5B%5D=white&name=John+Smith"
+      form.to_s.should == "age=29&colors[]=brown&colors[]=green&colors[]=white&name=John Smith"
     end
   end
 end


### PR DESCRIPTION
I've changed Utils#traversal_to_param_string to use the escape option that is given to it. I've also fixed a few broken specs related to that change.
