### PR TITLE
Add a new option (disable_ssl_peer_verification) to the request class.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -248,6 +248,12 @@ Now, even if you have libcurl built with OpenSSL you may still have a messed up 
 Typhoeus::Request.get("https://mail.google.com/mail", :disable_ssl_peer_verification => true)
 </pre>
 
+If you are getting "SSL: certificate subject name does not match target host name" from curl (ex:- you are trying to access to b.c.host.com when the certificate subject is *.host.com). You can disable host verification. Like this:
+
+<pre>
+Typhoeus::Request.get("https://mail.google.com/mail", :disable_ssl_host_verification => true)
+</pre>
+
 *LibCurl*
 Typhoeus also has a more raw libcurl interface. These are the Easy and Multi objects. If you're into accessing just the raw libcurl style, those are your best bet.
 

--- a/lib/typhoeus/easy.rb
+++ b/lib/typhoeus/easy.rb
@@ -33,6 +33,7 @@ module Typhoeus
       :CURLOPT_PROXYTYPE      => 101,
       :CURLOPT_PROXYAUTH      => 111,
       :CURLOPT_VERIFYPEER     => 64,
+      :CURLOPT_VERIFYHOST    => 81,
       :CURLOPT_NOBODY         => 44,
       :CURLOPT_ENCODING       => 10000 + 102,
       :CURLOPT_SSLCERT        => 10025,
@@ -196,6 +197,10 @@ module Typhoeus
 
     def disable_ssl_peer_verification
       set_option(OPTION_VALUES[:CURLOPT_VERIFYPEER], 0)
+    end
+
+    def disable_ssl_host_verification
+      set_option(OPTION_VALUES[:CURLOPT_VERIFYHOST], 0)
     end
 
     def method=(method)

--- a/lib/typhoeus/hydra.rb
+++ b/lib/typhoeus/hydra.rb
@@ -170,6 +170,7 @@ module Typhoeus
       easy.follow_location = request.follow_location if request.follow_location
       easy.max_redirects = request.max_redirects if request.max_redirects
       easy.disable_ssl_peer_verification if request.disable_ssl_peer_verification
+      easy.disable_ssl_host_verification if request.disable_ssl_host_verification
       easy.ssl_cert         = request.ssl_cert
       easy.ssl_cert_type    = request.ssl_cert_type
       easy.ssl_key          = request.ssl_key

--- a/lib/typhoeus/request.rb
+++ b/lib/typhoeus/request.rb
@@ -7,7 +7,7 @@ module Typhoeus
     attr_accessor :method, :params, :body, :connect_timeout, :timeout,
                   :user_agent, :response, :cache_timeout, :follow_location,
                   :max_redirects, :proxy, :proxy_username,:proxy_password,
-                  :disable_ssl_peer_verification, :interface,
+                  :disable_ssl_peer_verification, :disable_ssl_host_verification, :interface,
                   :ssl_cert, :ssl_cert_type, :ssl_key, :ssl_key_type,
                   :ssl_key_password, :ssl_cacert, :ssl_capath, :verbose,
                   :username, :password, :auth_method, :user_agent,
@@ -31,6 +31,7 @@ module Typhoeus
     # ** +:max_redirects
     # ** +:proxy
     # ** +:disable_ssl_peer_verification
+    # ** +:disable_ssl_host_verification
     # ** +:ssl_cert
     # ** +:ssl_cert_type
     # ** +:ssl_key
@@ -61,6 +62,7 @@ module Typhoeus
       @proxy_password   = options[:proxy_password]
       @proxy_auth_method = options[:proxy_auth_method]
       @disable_ssl_peer_verification = options[:disable_ssl_peer_verification]
+      @disable_ssl_host_verification = options[:disable_ssl_host_verification]
       @ssl_cert         = options[:ssl_cert]
       @ssl_cert_type    = options[:ssl_cert_type]
       @ssl_key          = options[:ssl_key]


### PR DESCRIPTION
Which will set the libcurl option SSL_VERIFYHOST to 0.

This can help if you trying to access x.y.host.com (ex: https://android.apis.google.com) and the certificate
is not valid for x (https://android.apis.google.com) but only for y.host.com (https://*.google.com)...etc.

Setting disable_ssl_peer_verification => true is not enough in this situation. As disable_ssl_peer_verification only make curl skip the certificate validation but not the subject name verification (which will result in the error -> SSL: certificate subject name does not match target host name).
