### PR TITLE
Clear memoized requests after invoking their callbacks

### DIFF
--- a/lib/typhoeus/hydra.rb
+++ b/lib/typhoeus/hydra.rb
@@ -219,7 +219,7 @@ module Typhoeus
       @on_complete.call(response) if @on_complete
 
       request.call_handlers
-      if requests = @memoized_requests[request.url]
+      if requests = @memoized_requests.delete(request.url)
         requests.each do |r|
           r.response = response
           r.call_handlers


### PR DESCRIPTION
A Typhoeus::Hydra instance, by default, memoizes outgoing requests. It
does so by maintaining hash keyed by URL, with values containing
requests to that URL. When a request is enqueued, if another request to
the same URL has previously been enqueued, it simply places that request
in the memoized hash.  Then when the real request completes, it iterates over
the duplicate requests in the memoized hash and calls the callback on each one
with the response.

The problem comes when we enqueue requests in the hydra after the
hydra has started running, which Typhoeus allows. Consider the following pattern
of requests:
- Request to http://a.com
  - When it completes, make a request to http://z.com
- Request to http://b.com
  - When it completes, make a request to http://z.com

The following sequence of events can thus occur:
1. Request to http://a.com completes: enqueue request to http://z.com
2. Request to http://z.com completes: memoize array is currently empty
3. Request to http://b.com completes: put request to http://z.com in
    the memoize hash

And that's it. The handler for the second request to z.com never
fires, because the memoize array was already scanned in step 2.

Below is a simple if non-ideal fix: we just delete the entry in the
memoize hash once the real request has completed. This way, Step 3 will now
find no entry in the memoize hash for http://z.com, and thus it will re-run
the real request.

It would be possible to save all the responses that have come back for
the hydra keyed by URL; if a previously-received request were re-run, we'd
just synchronously yield the response. This is more work, however, and also
would involve keeping a lot of data in memory just to handle this edge case.
