### PR TITLE
Fix to issue #111

### DIFF
--- a/ext/typhoeus/typhoeus_multi.c
+++ b/ext/typhoeus/typhoeus_multi.c
@@ -92,7 +92,7 @@ static void multi_read_info(VALUE self, CURLM *multi_handle) {
       else if ((response_code >= 200 && response_code < 300) || response_code == 0) {
         rb_funcall(easy, rb_intern("success"), 0);
       }
-      else if (response_code >= 300 && response_code < 600) {
+      else {
         rb_funcall(easy, rb_intern("failure"), 0);
       }
     }


### PR DESCRIPTION
make sure to call the Easy::failure callback on all non-success http response codes, even invalid ones.
