### PR TITLE
Need to accept and to_i strings for timeout/connect_timeout/cache_timeout values

### DIFF
--- a/lib/typhoeus/request.rb
+++ b/lib/typhoeus/request.rb
@@ -48,12 +48,12 @@ module Typhoeus
       @method           = options[:method] || :get
       @params           = options[:params]
       @body             = options[:body]
-      @timeout          = options[:timeout]
-      @connect_timeout  = options[:connect_timeout]
+      @timeout          = safe_to_i(options[:timeout])
+      @connect_timeout  = safe_to_i(options[:connect_timeout])
       @interface        = options[:interface]
       @headers          = options[:headers] || {}
       @user_agent       = options[:user_agent] || Typhoeus::USER_AGENT
-      @cache_timeout    = options[:cache_timeout]
+      @cache_timeout    = safe_to_i(options[:cache_timeout])
       @follow_location  = options[:follow_location]
       @max_redirects    = options[:max_redirects]
       @proxy            = options[:proxy]
@@ -201,5 +201,14 @@ module Typhoeus
     def self.head(url, params = {})
       run(url, params.merge(:method => :head))
     end
+
+    private
+
+      def safe_to_i value
+        return value if value.is_a?(Fixnum)
+        return nil if value.nil?
+        return nil if value.respond_to?(:empty?) && value.empty?
+        value.to_i
+      end
   end
 end

--- a/spec/typhoeus/request_spec.rb
+++ b/spec/typhoeus/request_spec.rb
@@ -76,7 +76,7 @@ describe Typhoeus::Request do
                                       })
       request.params_string.should == "a=789&a=2434"
     end
-    
+
     it "should allow the newer bracket notation for array params" do
       request = Typhoeus::Request.new('http://google.com',
                                       :params => {
@@ -162,8 +162,48 @@ describe Typhoeus::Request do
     Typhoeus::Request.new("http://localhost:3000", :timeout => 10).timeout.should == 10
   end
 
+  it "accepts a string for the timeout option" do
+    Typhoeus::Request.new("http://localhost:3000", :timeout => "150").timeout.should == 150
+  end
+
+  it "doesn't convert a nil timeout to an integer" do
+    Typhoeus::Request.new("http://localhost:3000", :timeout => nil).timeout.should_not == nil.to_i
+  end
+
+  it "doesn't convert an empty timeout to an integer" do
+    Typhoeus::Request.new("http://localhost:3000", :timeout => "").timeout.should_not == "".to_i
+  end
+
+  it "takes connect_timeout as an option" do
+    Typhoeus::Request.new("http://localhost:3000", :connect_timeout => 14).connect_timeout.should == 14
+  end
+
+  it "accepts a string for the connect_timeout option" do
+    Typhoeus::Request.new("http://localhost:3000", :connect_timeout => "420").connect_timeout.should == 420
+  end
+
+  it "doesn't convert a nil connect_timeout to an integer" do
+    Typhoeus::Request.new("http://localhost:3000", :connect_timeout => nil).connect_timeout.should_not == nil.to_i
+  end
+
+  it "doesn't convert an empty connect_timeout to an integer" do
+    Typhoeus::Request.new("http://localhost:3000", :connect_timeout => "").connect_timeout.should_not == "".to_i
+  end
+
   it "takes cache_timeout as an option" do
     Typhoeus::Request.new("http://localhost:3000", :cache_timeout => 60).cache_timeout.should == 60
+  end
+
+  it "accepts a string for the cache_timeout option" do
+    Typhoeus::Request.new("http://localhost:3000", :cache_timeout => "42").cache_timeout.should == 42
+  end
+
+  it "doesn't convert a nil cache_timeout to an integer" do
+    Typhoeus::Request.new("http://localhost:3000", :cache_timeout => nil).cache_timeout.should_not == nil.to_i
+  end
+
+  it "doesn't convert an empty cache_timeout to an integer" do
+    Typhoeus::Request.new("http://localhost:3000", :cache_timeout => "").cache_timeout.should_not == "".to_i
   end
 
   it "takes follow_location as an option" do


### PR DESCRIPTION
Yo,

I just made this commit on a Groupon fork:

"Accept and convert strings to integers in Typhoeus::Request#initialize for timeout/cache_timeout/connect_timeout values when using ruby 1.9.x."

I've been working on the Groupon ruby 1.9.x upgrade and ran into an issue in typhoeus. We're pulling timeout settings from a yml file, and Typhoeus::Requests with timeouts that are set to strings manifest in an "error on thread select" while on 1.9.2. This patch converts these strings to integers while ignoring nils and empties.

I originally thought I had to recompile curl with c-ares (only 7.21.1 or less worked), as this seemed to get around a race condition created by this, but that's just a guess (and apparently a red herring). I only saw this on OS X Lion, which natively has curl 7.21.4 without c-ares, but I suspect it might replicate on other OS X variants/curls with a bit more work (or luck). A co-worker couldn't replicate on 1.9.2-p180 with curl 7.19.7 without c-ares on OS X Snow Leopard, but I'm guessing his system was just winning the race on a defaulted timeout value.

I made a little testing script that supplied a string value for the timeout, and by repeatedly running that script I could _occasionally_ get the error on thread select.

We actually aren't setting cache_timeout, but I threw that one in there for good measure. Let me know if that's a mistake and I'll redo this without converting that to_i.

I hope this helps! Please don't hesitate to send any other questions/comments my way.

/Dave Nawara
