### PR TITLE
Construct a properly formatted headers string when stubbing headers_hash.

### DIFF
--- a/lib/typhoeus/response.rb
+++ b/lib/typhoeus/response.rb
@@ -17,7 +17,7 @@ module Typhoeus
       @curl_error_message    = params[:curl_error_message]
       @status_message        = params[:status_message]
       @http_version          = params[:http_version]
-      @headers               = params[:headers] || ''
+      @headers               = params[:headers]
       @body                  = params[:body]
       @time                  = params[:time]
       @requested_url         = params[:requested_url]
@@ -37,6 +37,10 @@ module Typhoeus
     # Returns true if this is a mock response.
     def mock?
       @mock
+    end
+
+    def headers
+      @headers ||= @headers_hash ? construct_header_string : ''
     end
 
     def headers_hash
@@ -85,7 +89,20 @@ module Typhoeus
     private
 
       def first_header_line
-        @first_header_line ||= headers.split("\n").first
+        @first_header_line ||= @headers.to_s.split("\n").first
+      end
+
+      def construct_header_string
+        lines = ["HTTP/#{http_version} #{code} #{status_message}"]
+
+        @headers_hash.each do |key, values|
+          [values].flatten.each do |value|
+            lines << "#{key}: #{value}"
+          end
+        end
+
+        lines << '' << ''
+        lines.join("\r\n")
       end
   end
 end

--- a/spec/servers/app.rb
+++ b/spec/servers/app.rb
@@ -15,6 +15,10 @@ post '/file' do
   }.to_json
 end
 
+get '/multiple-headers' do
+  [200, { 'Set-Cookie' => %w[ foo bar ], 'Content-Type' => 'text/plain' }, ['']]
+end
+
 get '/fail/:number' do
   if @@fail_count >= params[:number].to_i
     "ok"


### PR DESCRIPTION
Construct a properly formatted headers string when stubbing headers_hash.

This is important when using Typhoeus with Faraday and stubbing with a tool like VCR that only stubs the headers_hash.  Faraday manually parses the header string so we need to ensure it is set as well:

https://github.com/technoweenie/faraday/blob/v0.7.4/lib/faraday/adapter/typhoeus.rb#L38
