### PR TITLE
Allow users to register custom stub finders.

### DIFF
--- a/lib/typhoeus/hydra/stubbing.rb
+++ b/lib/typhoeus/hydra/stubbing.rb
@@ -11,8 +11,24 @@ module Typhoeus
           self.stubs = []
         end
 
+        def register_stub_finder(&block)
+          stub_finders << block
+        end
+
         def find_stub_from_request(request)
+          stub_finders.each do |finder|
+            if response = finder.call(request)
+              mock = HydraMock.new(/.*/, :any)
+              mock.and_return(response)
+              return mock
+            end
+          end
+
           stubs.detect { |stub| stub.matches?(request) }
+        end
+
+        def stub_finders
+          @stub_finders ||= []
         end
 
         def self.extended(base)


### PR DESCRIPTION
VCR 2.0.0 beta1 monkey patches typhoeus to achieve this functionality.  This allows the same functionality without monkey patching.  See:

https://github.com/myronmarston/vcr/blob/v2.0.0.beta1/lib/vcr/library_hooks/typhoeus.rb#L82-89
