### PR TITLE
POST params need to be encoded

### DIFF
--- a/lib/typhoeus/request.rb
+++ b/lib/typhoeus/request.rb
@@ -108,6 +108,7 @@ module Typhoeus
       @auth_method      = options[:auth_method]
 
       if @method == :post
+        @params = @params ? Typhoeus::Utils.escape_params(@params) : nil
         @url = url
       else
         @url = @params ? "#{url}?#{params_string}" : url

--- a/lib/typhoeus/utils.rb
+++ b/lib/typhoeus/utils.rb
@@ -10,6 +10,14 @@ module Typhoeus
     end
     module_function :escape
 
+    def escape_params(params)
+      traverse_params_hash(params)[:params].inject({}) do |memo, (k, v)|
+        memo[escape(k)] = escape(v)
+        memo
+      end
+    end
+    module_function :escape_params
+
     # Params are NOT escaped.
     def traverse_params_hash(hash, result = nil, current_key = nil)
       result ||= { :files => [], :params => [] }

--- a/spec/typhoeus/request_spec.rb
+++ b/spec/typhoeus/request_spec.rb
@@ -91,60 +91,68 @@ describe Typhoeus::Request do
     end
   end
 
-  describe "#params_string" do
-    it "should dump a sorted string" do
-      request = Typhoeus::Request.new(
-        "http://google.com",
-        :params => {
-          'b' => 'fdsa',
-          'a' => 'jlk',
-          'c' => '789'
-        }
-      )
+  context 'parsing params' do
+    describe "#params_string" do
+      it "should dump a sorted string" do
+        request = Typhoeus::Request.new(
+          "http://google.com",
+          :params => {
+            'b' => 'fdsa',
+            'a' => 'jlk',
+            'c' => '789'
+          }
+        )
 
-      request.params_string.should == "a=jlk&b=fdsa&c=789"
+        request.params_string.should == "a=jlk&b=fdsa&c=789"
+      end
+
+      it "should accept symboled keys" do
+        request = Typhoeus::Request.new('http://google.com',
+                                        :params => {
+                                          :b => 'fdsa',
+                                          :a => 'jlk',
+                                          :c => '789'
+                                        })
+        request.params_string.should == "a=jlk&b=fdsa&c=789"
+      end
+
+      it "should translate params with values that are arrays to the proper format" do
+        request = Typhoeus::Request.new('http://google.com',
+                                        :params => {
+                                          :a => ['789','2434']
+                                        })
+        request.params_string.should == "a=789&a=2434"
+      end
+
+      it "should allow the newer bracket notation for array params" do
+        request = Typhoeus::Request.new('http://google.com',
+                                        :params => {
+                                          "a[]" => ['789','2434']
+                                        })
+        request.params_string.should == "a%5B%5D=789&a%5B%5D=2434"
+      end
+
+      it "should nest arrays in hashes" do
+        request = Typhoeus::Request.new('http://google.com',
+                                        :params => {
+                                          :a => { :b => { :c => ['d','e'] } }
+                                        })
+        request.params_string.should == "a%5Bb%5D%5Bc%5D=d&a%5Bb%5D%5Bc%5D=e"
+      end
+
+      it "should translate nested params correctly" do
+        request = Typhoeus::Request.new('http://google.com',
+                                        :params => {
+                                          :a => { :b => { :c => 'd' } }
+                                        })
+        request.params_string.should == "a%5Bb%5D%5Bc%5D=d"
+      end
     end
-
-    it "should accept symboled keys" do
-      request = Typhoeus::Request.new('http://google.com',
-                                      :params => {
-                                        :b => 'fdsa',
-                                        :a => 'jlk',
-                                        :c => '789'
-                                      })
-      request.params_string.should == "a=jlk&b=fdsa&c=789"
-    end
-
-    it "should translate params with values that are arrays to the proper format" do
-      request = Typhoeus::Request.new('http://google.com',
-                                      :params => {
-                                        :a => ['789','2434']
-                                      })
-      request.params_string.should == "a=789&a=2434"
-    end
-
-    it "should allow the newer bracket notation for array params" do
-      request = Typhoeus::Request.new('http://google.com',
-                                      :params => {
-                                        "a[]" => ['789','2434']
-                                      })
-      request.params_string.should == "a%5B%5D=789&a%5B%5D=2434"
-    end
-
-    it "should nest arrays in hashes" do
-      request = Typhoeus::Request.new('http://google.com',
-                                      :params => {
-                                        :a => { :b => { :c => ['d','e'] } }
-                                      })
-      request.params_string.should == "a%5Bb%5D%5Bc%5D=d&a%5Bb%5D%5Bc%5D=e"
-    end
-
-    it "should translate nested params correctly" do
-      request = Typhoeus::Request.new('http://google.com',
-                                      :params => {
-                                        :a => { :b => { :c => 'd' } }
-                                      })
-      request.params_string.should == "a%5Bb%5D%5Bc%5D=d"
+    describe '#new' do
+      it 'parses query parameters for a POST request' do
+        request = Typhoeus::Request.new("http://localhost:3000", :params => {:q => "hello & there" }, :method => :post)
+        request.params.should == { "q" => "hello+%26+there" }
+      end
     end
   end
 


### PR DESCRIPTION
Hey there,

We ran into an issue when Using Request#post - the params were not being encoded so if we had special characters as the values for the params they were not being sent correctly. The patch I have fixes the problem (although not sure if there is a more elegant way.)

Thanks,
Rohan
