### PR TITLE
Fix 'incompatible encoding regexp match (UTF-8 regexp with ASCII-8BIT string)'

### DIFF
--- a/lib/typhoeus/utils.rb
+++ b/lib/typhoeus/utils.rb
@@ -4,7 +4,7 @@ module Typhoeus
   module Utils
     # Taken from Rack::Utils, 1.2.1 to remove Rack dependency.
     def escape(s)
-      s.to_s.gsub(/([^ a-zA-Z0-9_.-]+)/u) {
+      s.to_s.unpack('C*').pack('U*').gsub(/([^ a-zA-Z0-9_.-]+)/u) {
         '%'+$1.unpack('H2'*bytesize($1)).join('%').upcase
       }.tr(' ', '+')
     end


### PR DESCRIPTION
When ASCII characters which do not parse in UTF-8 were being passed to Utils#escape the gsub operation crashed. This method works for all cases tested as opposed to the String#encode method which (as of 1.9.3-p125) is not 100%.
