### PR TITLE
removing git ls-files from gemspec

### DIFF
--- a/typhoeus.gemspec
+++ b/typhoeus.gemspec
@@ -2,6 +2,7 @@
 
 $:.unshift File.expand_path('../lib', __FILE__)
 require 'typhoeus/version'
+require 'rubygems/package_task'
 
 Gem::Specification.new do |s|
   s.name         = "typhoeus"
@@ -12,7 +13,9 @@ Gem::Specification.new do |s|
   s.summary      = "Parallel HTTP library on top of libcurl multi."
   s.description  = %q{Like a modern code version of the mythical beast with 100 serpent heads, Typhoeus runs HTTP requests in parallel while cleanly encapsulating handling logic.}
   s.extensions   = ["ext/typhoeus/extconf.rb"]
-  s.files        = (`git ls-files ext lib spec`.split("\n")) + [
+  s.files        = FileList['ext/**/*', 
+                     'lib/**/*', 
+                     'spec/**/*',
                      'CHANGELOG.markdown',
                      'Gemfile',
                      'Gemfile.lock',


### PR DESCRIPTION
removing git ls-files from gemspec. this allows you to build the gem on machines that do not have git and/or do not have it checked out as a git repo
