### PR TITLE
allow to use activesupport 2.3, 3.0 and 3.1

### DIFF
--- a/typhoeus.gemspec
+++ b/typhoeus.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('ffi', ['~> 1.0'])
   s.add_dependency('mime-types', ['~> 1.18'])
-  s.add_dependency('activesupport', ['~> 3.2'])
+  s.add_dependency('activesupport', ['>= 2.3.2'])
 
   s.add_development_dependency('sinatra', ['~> 1.3'])
   s.add_development_dependency('json', ['~> 1.7'])


### PR DESCRIPTION
my project is using activesupport 2.3, and I found activesupport 2.3.2 also works in typhoeus.
