### PR TITLE
adjust spec wait timeout for jruby

### DIFF
--- a/spec/support/typhoeus_localhost_server.rb
+++ b/spec/support/typhoeus_localhost_server.rb
@@ -60,7 +60,7 @@ class TyphoeusLocalhostServer
     def wait_for_servers_to_start
       puts "Waiting for servers to start..."
 
-      Timeout::timeout(30) do
+      Timeout::timeout(RUBY_PLATFORM == 'java' ? 60 : 10) do
         loop do
           sleep 0.5 # give the forked server processes some time to start
 


### PR DESCRIPTION
jruby is just slow to start the 3 web servers. wait for longer on that platform

this will hopefully fix the travis.ci failure

perhaps we could make the timeout really high just to make sure? i don't know. i'll leave the rest up to you
