### PR TITLE
add support for socks5_hostname proxy_type

### DIFF
--- a/lib/typhoeus/curl.rb
+++ b/lib/typhoeus/curl.rb
@@ -353,11 +353,12 @@ module Typhoeus
       :auto,         0x1f] # all options or'd together
 
     Proxy = enum [
-      :http,     0,
-      :http_1_0, 1,
-      :socks4,   4,
-      :socks5,   5,
-      :socks4a,  6]
+      :http,            0,
+      :http_1_0,        1,
+      :socks4,          4,
+      :socks5,          5,
+      :socks4a,         6,
+      :socks5_hostname, 7]
 
     SSLVersion = enum [
       :default, 0,


### PR DESCRIPTION
Thus allowing hostname resolution on the server-side of the proxy.

The SOCKS5_HOSTNAME option has been in libcurl ever since SOCKS4A was
added.  For some unknown reason the socks4a option was added to
typhoeus, but socks5_hostname was not.
