### PR TITLE
Fix libcurl.so.4 load on Debian production systems

### DIFF
--- a/lib/typhoeus/curl.rb
+++ b/lib/typhoeus/curl.rb
@@ -414,7 +414,7 @@ module Typhoeus
     callback :callback, [:pointer, :size_t, :size_t, :pointer], :size_t
 
     ffi_lib_flags :now, :global
-    ffi_lib 'libcurl'
+    ffi_lib ['libcurl', 'libcurl.so.4']
 
     #
     # FFI function bindings definition


### PR DESCRIPTION
Typhoeus doesn't work on Debian when `libcurl-dev` is not installed.

On a Debian production system, you don't have the `libcurl-dev` package installed, you only have `libcurl4`.

As you can read here https://github.com/ffi/ffi/wiki/Loading-Libraries, `libcurl.so` is only installed by the `libcurl-dev` package. As a result, on a production Debian system, you only have the file `libcurl.so.4`, and not the file `libcurl.so`.

This patch follows ffi's recommendation to try to load  `libcurl.so.4` if `libcurl.so` is not found.
