### PR TITLE
cleanup multi to avoid memory leak

### DIFF
--- a/lib/typhoeus/hydra.rb
+++ b/lib/typhoeus/hydra.rb
@@ -95,6 +95,7 @@ module Typhoeus
       @multi.perform
     ensure
       @multi.reset_easy_handles{|easy| release_easy_object(easy)}
+      @multi.cleanup
       @memoized_requests = {}
       @retrieved_from_cache = {}
       @running_requests = 0

--- a/lib/typhoeus/multi.rb
+++ b/lib/typhoeus/multi.rb
@@ -114,7 +114,7 @@ module Typhoeus
     end
 
     def cleanup
-      Curl.multi_cleanup(@handle)
+      #Curl.multi_cleanup(@handle)
       @active = 0
       @running = 0
       @easy_handles = []


### PR DESCRIPTION
We used typhoeus very often with jruby server, torquebox, it caused memory leak and finally crashed the server.

After I add multi.cleanup, it works fine now, but I'm not sure if Curl.multi_cleanup is useless.
