### PR TITLE
Allow request url to be a lambda.

### DIFF
--- a/lib/typhoeus/request.rb
+++ b/lib/typhoeus/request.rb
@@ -30,10 +30,17 @@ module Typhoeus
     include Request::Stubbable
     include Request::Before
 
+    # Set the url.
+    #
+    # @return [ String ]
+    attr_writer :url
+
     # Returns the provided url.
     #
     # @return [ String ]
-    attr_accessor :url
+    def url
+      @url.respond_to?(:call) ? @url.call : @url
+    end
 
     # Returns options, which includes default parameters.
     #
@@ -88,6 +95,13 @@ module Typhoeus
     #     "www.example.com",
     #     followlocation: true
     #   ).run
+    #
+    # @example Evaluate a lazy url at request time.
+    #   request = Typhoeus::Request.new(
+    #     lambda { "http://example.com/?requested_at=#{Time.now.to_i}" }
+    #   )
+    #   # ...
+    #   response = request.run
     #
     # @param [ String ] url The url to request.
     # @param [ options ] options The options.

--- a/spec/typhoeus/request_spec.rb
+++ b/spec/typhoeus/request_spec.rb
@@ -7,7 +7,7 @@ describe Typhoeus::Request do
 
   describe ".new" do
     it "stores url" do
-      expect(request.url).to eq(url)
+      expect(request.instance_variable_get(:@url)).to eq(url)
     end
 
     it "stores options" do
@@ -102,6 +102,24 @@ describe Typhoeus::Request do
 
       it "has different hashes" do
         expect(request.hash).to_not eq(other.hash)
+      end
+    end
+  end
+
+  describe "#url" do
+    context "when a lambda" do
+      let(:url) { lambda { "localhost:3001" } }
+
+      it "evaluates and returns the value" do
+        expect(request.url).to eq(url.call)
+      end
+    end
+
+    context "when a value" do
+      let(:url) { "localhost:3001" }
+
+      it "returns the value" do
+        expect(request.url).to eq(url)
       end
     end
   end


### PR DESCRIPTION
I'm using this small patch to allow CloudFront URLs to be assembled and signed when the request is sent, rather than when the object is created. This avoids urls with an expiry time becoming invalid while waiting in a Hydra queue.
