### PR TITLE
Renamed url to base_url

### DIFF
--- a/lib/typhoeus.rb
+++ b/lib/typhoeus.rb
@@ -55,17 +55,17 @@ module Typhoeus
   #
   # @example (see Typhoeus::Expectation)
   #
-  # @param [ String ] url The url to stub out.
+  # @param [ String ] base_url The url to stub out.
   # @param [ Hash ] options The options to stub out.
   #
   # @return [ Typhoeus::Expectation ] The expecatation.
   #
   # @see Typhoeus::Expectation
-  def stub(url, options = {})
-    expectation = Expectation.all.find{ |e| e.url == url && e.options == options }
+  def stub(base_url, options = {})
+    expectation = Expectation.all.find{ |e| e.base_url == base_url && e.options == options }
     return expectation if expectation
 
-    Expectation.new(url, options).tap do |new_expectation|
+    Expectation.new(base_url, options).tap do |new_expectation|
       Expectation.all << new_expectation
     end
   end
@@ -73,7 +73,7 @@ module Typhoeus
   # Add before callbacks.
   #
   # @example Add before callback.
-  #   Typhoeus.before { |request| p request.url }
+  #   Typhoeus.before { |request| p request.base_url }
   #
   # @param [ Block ] block The callback.
   #

--- a/lib/typhoeus/expectation.rb
+++ b/lib/typhoeus/expectation.rb
@@ -17,7 +17,7 @@ module Typhoeus
   class Expectation
 
     # @api private
-    attr_reader :url
+    attr_reader :base_url
 
     # @api private
     attr_reader :options
@@ -66,13 +66,13 @@ module Typhoeus
     # Creates an expactation.
     #
     # @example Create expactation.
-    #   Typhoeus::Expectation.new(url)
+    #   Typhoeus::Expectation.new(base_url)
     #
     # @return [ Expectation ] The created expactation.
     #
     # @api private
-    def initialize(url, options = {})
-      @url = url
+    def initialize(base_url, options = {})
+      @base_url = base_url
       @options = options
       @response_counter = 0
       @from = nil
@@ -117,7 +117,7 @@ module Typhoeus
     #
     # @api private
     def matches?(request)
-      url_match?(request.url) && options_match?(request)
+      url_match?(request.base_url) && options_match?(request)
     end
 
     # Return canned responses.
@@ -157,18 +157,18 @@ module Typhoeus
       (options ? options.all?{ |k,v| request.original_options[k] == v || request.options[k] == v } : true)
     end
 
-    # Check wether the url matches the request url.
-    # The url can be a string, regex or nil. String and
+    # Check wether the base_url matches the request url.
+    # The base_url can be a string, regex or nil. String and
     # regexp were checked, nil is always true. Else false.
     #
     # Nil serves as a placeholder in case you want to match
     # all urls.
     def url_match?(request_url)
-      case url
+      case base_url
       when String
-        url == request_url
+        base_url == request_url
       when Regexp
-        !!request_url.match(url)
+        !!request_url.match(base_url)
       when nil
         true
       else

--- a/lib/typhoeus/hydra/easy_factory.rb
+++ b/lib/typhoeus/hydra/easy_factory.rb
@@ -49,7 +49,7 @@ module Typhoeus
       # @return [ Ethon::Easy ] The easy.
       def get
         easy.http_request(
-          request.url,
+          request.base_url,
           request.options.fetch(:method, :get),
           request.options.reject{|k,_| k==:method}
         )

--- a/lib/typhoeus/request.rb
+++ b/lib/typhoeus/request.rb
@@ -30,10 +30,10 @@ module Typhoeus
     include Request::Stubbable
     include Request::Before
 
-    # Returns the provided url.
+    # Returns the provided base url.
     #
     # @return [ String ]
-    attr_accessor :url
+    attr_accessor :base_url
 
     # Returns options, which includes default parameters.
     #
@@ -89,7 +89,7 @@ module Typhoeus
     #     followlocation: true
     #   ).run
     #
-    # @param [ String ] url The url to request.
+    # @param [ String ] base_url The url to request.
     # @param [ options ] options The options.
     #
     # @option options [ Hash ] :params Translated
@@ -104,12 +104,16 @@ module Typhoeus
     # @see Typhoeus::Hydra
     # @see Typhoeus::Response
     # @see Typhoeus::Request::Actions
-    def initialize(url, options = {})
-      @url = url
+    def initialize(base_url, options = {})
+      @base_url = base_url
       @original_options = options
       @options = options.dup
 
       set_defaults
+    end
+    
+    def url
+      base_url
     end
 
     # Returns wether other is equal to self.
@@ -124,7 +128,7 @@ module Typhoeus
     # @api private
     def eql?(other)
       self.class == other.class &&
-        self.url == other.url &&
+        self.base_url == other.base_url &&
         fuzzy_hash_eql?(self.options, other.options)
     end
 
@@ -134,7 +138,7 @@ module Typhoeus
     #
     # @api private
     def hash
-      [ self.class, self.url, self.options ].hash
+      [ self.class, self.base_url, self.options ].hash
     end
 
     private

--- a/lib/typhoeus/request/actions.rb
+++ b/lib/typhoeus/request/actions.rb
@@ -18,8 +18,8 @@ module Typhoeus
       # @return (see Typhoeus::Request#initialize)
       #
       # @note (see Typhoeus::Request#initialize)
-      def get(url, options = {})
-        Request.new(url, options.merge(:method => :get)).run
+      def get(base_url, options = {})
+        Request.new(base_url, options.merge(:method => :get)).run
       end
 
       # Make a post request.
@@ -34,8 +34,8 @@ module Typhoeus
       # @return (see Typhoeus::Request#initialize)
       #
       # @note (see Typhoeus::Request#initialize)
-      def post(url, options = {})
-        Request.new(url, options.merge(:method => :post)).run
+      def post(base_url, options = {})
+        Request.new(base_url, options.merge(:method => :post)).run
       end
 
       # Make a put request.
@@ -46,15 +46,15 @@ module Typhoeus
       # @param (see Typhoeus::Request#initialize)
       #
       # @option options :params [ Hash ] Params hash which
-      #   is attached to the url.
+      #   is attached to the base_url.
       # @option options :body [ Hash ] Body hash which
       #   becomes a PUT request body.
       #
       # @return (see Typhoeus::Request#initialize)
       #
       # @note (see Typhoeus::Request#initialize)
-      def put(url, options = {})
-        Request.new(url, options.merge(:method => :put)).run
+      def put(base_url, options = {})
+        Request.new(base_url, options.merge(:method => :put)).run
       end
 
       # Make a delete request.
@@ -69,8 +69,8 @@ module Typhoeus
       # @return (see Typhoeus::Request#initialize)
       #
       # @note (see Typhoeus::Request#initialize)
-      def delete(url, options = {})
-        Request.new(url, options.merge(:method => :delete)).run
+      def delete(base_url, options = {})
+        Request.new(base_url, options.merge(:method => :delete)).run
       end
 
       # Make a head request.
@@ -85,8 +85,8 @@ module Typhoeus
       # @return (see Typhoeus::Request#initialize)
       #
       # @note (see Typhoeus::Request#initialize)
-      def head(url, options = {})
-        Request.new(url, options.merge(:method => :head)).run
+      def head(base_url, options = {})
+        Request.new(base_url, options.merge(:method => :head)).run
       end
 
       # Make a patch request.
@@ -101,8 +101,8 @@ module Typhoeus
       # @return (see Typhoeus::Request#initialize)
       #
       # @note (see Typhoeus::Request#initialize)
-      def patch(url, options = {})
-        Request.new(url, options.merge(:method => :patch)).run
+      def patch(base_url, options = {})
+        Request.new(base_url, options.merge(:method => :patch)).run
       end
 
       # Make a options request.
@@ -117,8 +117,8 @@ module Typhoeus
       # @return (see Typhoeus::Request#initialize)
       #
       # @note (see Typhoeus::Request#initialize)
-      def options(url, options = {})
-        Request.new(url, options.merge(:method => :options)).run
+      def options(base_url, options = {})
+        Request.new(base_url, options.merge(:method => :options)).run
       end
     end
   end

--- a/lib/typhoeus/request/operations.rb
+++ b/lib/typhoeus/request/operations.rb
@@ -15,7 +15,7 @@ module Typhoeus
         easy = Typhoeus.get_easy
         begin
           easy.http_request(
-            url,
+            base_url,
             options.fetch(:method, :get),
             options.reject{|k,_| k==:method}
           )

--- a/perf/profile.rb
+++ b/perf/profile.rb
@@ -2,11 +2,11 @@ require 'typhoeus'
 require 'ruby-prof'
 
 calls = 50
-url = "http://127.0.0.1:3000/"
+base_url = "http://127.0.0.1:3000/"
 
 RubyProf.start
 calls.times do |i|
-  Typhoeus::Request.get(url+i.to_s)
+  Typhoeus::Request.get(base_url+i.to_s)
 end
 result = RubyProf.stop
 

--- a/spec/support/boot.rb
+++ b/spec/support/boot.rb
@@ -45,9 +45,9 @@ class Boot
     def servers_running?
       up = 0
       PORTS.each do |port|
-        url = "http://localhost:#{port}/"
+        base_url = "http://localhost:#{port}/"
         begin
-          response = Net::HTTP.get_response(URI.parse(url))
+          response = Net::HTTP.get_response(URI.parse(base_url))
           if response.is_a?(Net::HTTPSuccess)
             up += 1
           end

--- a/spec/typhoeus/adapters/faraday_spec.rb
+++ b/spec/typhoeus/adapters/faraday_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 require 'typhoeus/adapters/faraday'
 
 describe Faraday::Adapter::Typhoeus do
-  let(:url) { "http://localhost:3001" }
+  let(:base_url) { "http://localhost:3001" }
   let(:adapter) { described_class.new }
-  let(:request) { Typhoeus::Request.new(url) }
+  let(:request) { Typhoeus::Request.new(base_url) }
   let(:conn) do
-    Faraday.new(:url => url) do |faraday|
+    Faraday.new(:url => base_url) do |faraday|
       faraday.adapter  :typhoeus
     end
   end
@@ -79,7 +79,7 @@ describe Faraday::Adapter::Typhoeus do
     end
 
     it "sets url" do
-      expect(request.url).to eq("url")
+      expect(request.base_url).to eq("url")
     end
 
     it "sets http method" do

--- a/spec/typhoeus/expectation_spec.rb
+++ b/spec/typhoeus/expectation_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 describe Typhoeus::Expectation do
   let(:options) { {} }
-  let(:url) { "www.example.com" }
-  let(:expectation) { described_class.new(url, options) }
+  let(:base_url) { "www.example.com" }
+  let(:expectation) { described_class.new(base_url, options) }
 
   after(:each) { Typhoeus::Expectation.clear }
 
   describe ".new" do
-    it "sets url" do
-      expect(expectation.instance_variable_get(:@url)).to eq(url)
+    it "sets base_url" do
+      expect(expectation.instance_variable_get(:@base_url)).to eq(base_url)
     end
 
     it "sets options" do
@@ -116,7 +116,7 @@ describe Typhoeus::Expectation do
   end
 
   describe "#matches?" do
-    let(:request) { stub(:url => nil) }
+    let(:request) { stub(:base_url => nil) }
 
     it "calls url_match?" do
       expectation.should_receive(:url_match?)
@@ -133,7 +133,7 @@ describe Typhoeus::Expectation do
   describe "#url_match?" do
     let(:request_url) { "www.example.com" }
     let(:request) { Typhoeus::Request.new(request_url) }
-    let(:url_match) { expectation.method(:url_match?).call(request.url) }
+    let(:url_match) { expectation.method(:url_match?).call(request.base_url) }
 
     context "when string" do
       context "when match" do
@@ -143,7 +143,7 @@ describe Typhoeus::Expectation do
       end
 
       context "when no match" do
-        let(:url) { "no_match" }
+        let(:base_url) { "no_match" }
 
         it "returns false" do
           expect(url_match).to be_false
@@ -153,7 +153,7 @@ describe Typhoeus::Expectation do
 
     context "when regexp" do
       context "when match" do
-        let(:url) { /example/ }
+        let(:base_url) { /example/ }
 
         it "returns true" do
           expect(url_match).to be_true
@@ -161,7 +161,7 @@ describe Typhoeus::Expectation do
       end
 
       context "when no match" do
-        let(:url) { /nomatch/ }
+        let(:base_url) { /nomatch/ }
 
         it "returns false" do
           expect(url_match).to be_false
@@ -170,7 +170,7 @@ describe Typhoeus::Expectation do
     end
 
     context "when nil" do
-      let(:url) { nil }
+      let(:base_url) { nil }
 
       it "returns true" do
         expect(url_match).to be_true
@@ -178,7 +178,7 @@ describe Typhoeus::Expectation do
     end
 
     context "when not string, regexp, nil" do
-      let(:url) { 1 }
+      let(:base_url) { 1 }
 
       it "returns false" do
         expect(url_match).to be_false

--- a/spec/typhoeus/hydra/before_spec.rb
+++ b/spec/typhoeus/hydra/before_spec.rb
@@ -10,7 +10,7 @@ describe Typhoeus::Hydra::Before do
     context "when before" do
       context "when one" do
         it "executes" do
-          Typhoeus.before { |r| String.new(r.url) }
+          Typhoeus.before { |r| String.new(r.base_url) }
           String.should_receive(:new).and_return("")
           hydra.add(request)
         end
@@ -42,7 +42,7 @@ describe Typhoeus::Hydra::Before do
 
       context "when multi" do
         context "when all true" do
-          before { 3.times { Typhoeus.before { |r| String.new(r.url) } } }
+          before { 3.times { Typhoeus.before { |r| String.new(r.base_url) } } }
 
           it "calls super" do
             Typhoeus::Expectation.should_receive(:find_by)
@@ -57,9 +57,9 @@ describe Typhoeus::Hydra::Before do
 
         context "when middle false" do
           before do
-            Typhoeus.before { |r| String.new(r.url) }
-            Typhoeus.before { |r| String.new(r.url); nil }
-            Typhoeus.before { |r| String.new(r.url) }
+            Typhoeus.before { |r| String.new(r.base_url) }
+            Typhoeus.before { |r| String.new(r.base_url); nil }
+            Typhoeus.before { |r| String.new(r.base_url) }
           end
 
           it "doesn't call super" do

--- a/spec/typhoeus/hydra/block_connection_spec.rb
+++ b/spec/typhoeus/hydra/block_connection_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe Typhoeus::Hydra::BlockConnection do
-  let(:url) { "localhost:3001" }
+  let(:base_url) { "localhost:3001" }
   let(:hydra) { Typhoeus::Hydra.new() }
-  let(:request) { Typhoeus::Request.new(url, {:method => :get}) }
+  let(:request) { Typhoeus::Request.new(base_url, {:method => :get}) }
 
   describe "add" do
     context "when block_connection activated" do

--- a/spec/typhoeus/hydra/easy_factory_spec.rb
+++ b/spec/typhoeus/hydra/easy_factory_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe Typhoeus::Hydra::EasyFactory do
-  let(:url) { "http://localhost:3001" }
+  let(:base_url) { "http://localhost:3001" }
   let(:hydra) { Typhoeus::Hydra.new(:max_concurrency => 0) }
   let(:headers) { {} }
-  let(:request) { Typhoeus::Request.new(url, :headers => headers) }
+  let(:request) { Typhoeus::Request.new(base_url, :headers => headers) }
 
   describe "#set_callback" do
     let(:easy_factory) { described_class.new(request, hydra) }

--- a/spec/typhoeus/hydra/memoizable_spec.rb
+++ b/spec/typhoeus/hydra/memoizable_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe Typhoeus::Hydra::Memoizable do
-  let(:url) { "localhost:3001" }
+  let(:base_url) { "localhost:3001" }
   let(:hydra) { Typhoeus::Hydra.new() }
-  let(:request) { Typhoeus::Request.new(url, {:method => :get}) }
+  let(:request) { Typhoeus::Request.new(base_url, {:method => :get}) }
 
   describe "add" do
     context "when memoization activated" do

--- a/spec/typhoeus/hydra/queueable_spec.rb
+++ b/spec/typhoeus/hydra/queueable_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Typhoeus::Hydra::Queueable do
-  let(:url) { "localhost:3001" }
+  let(:base_url) { "localhost:3001" }
   let(:options) { {} }
   let(:hydra) { Typhoeus::Hydra.new(options) }
 

--- a/spec/typhoeus/hydra/runnable_spec.rb
+++ b/spec/typhoeus/hydra/runnable_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Typhoeus::Hydra::Runnable do
-  let(:url) { "localhost:3001" }
+  let(:base_url) { "localhost:3001" }
   let(:options) { {} }
   let(:hydra) { Typhoeus::Hydra.new(options) }
 

--- a/spec/typhoeus/hydra/stubbable_spec.rb
+++ b/spec/typhoeus/hydra/stubbable_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
 describe Typhoeus::Hydra::Stubbable do
-  let(:url) { "localhost:3001" }
-  let(:request) { Typhoeus::Request.new(url) }
+  let(:base_url) { "localhost:3001" }
+  let(:request) { Typhoeus::Request.new(base_url) }
   let(:response) { Typhoeus::Response.new }
   let(:hydra) { Typhoeus::Hydra.new }
 
-  before { Typhoeus.stub(url).and_return(response) }
+  before { Typhoeus.stub(base_url).and_return(response) }
   after { Typhoeus::Expectation.clear }
 
   describe "#add" do

--- a/spec/typhoeus/hydra_spec.rb
+++ b/spec/typhoeus/hydra_spec.rb
@@ -1,7 +1,7 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe Typhoeus::Hydra do
-  let(:url) { "localhost:3001" }
+  let(:base_url) { "localhost:3001" }
   let(:options) { {} }
   let(:hydra) { Typhoeus::Hydra.new(options) }
 

--- a/spec/typhoeus/request/before_spec.rb
+++ b/spec/typhoeus/request/before_spec.rb
@@ -9,7 +9,7 @@ describe Typhoeus::Request::Before do
     context "when before" do
       context "when one" do
         it "executes" do
-          Typhoeus.before { |r| String.new(r.url) }
+          Typhoeus.before { |r| String.new(r.base_url) }
           String.should_receive(:new).and_return("")
           request.run
         end
@@ -41,7 +41,7 @@ describe Typhoeus::Request::Before do
 
       context "when multi" do
         context "when all true" do
-          before { 3.times { Typhoeus.before { |r| String.new(r.url) } } }
+          before { 3.times { Typhoeus.before { |r| String.new(r.base_url) } } }
 
           it "calls super" do
             Typhoeus::Expectation.should_receive(:find_by)
@@ -56,9 +56,9 @@ describe Typhoeus::Request::Before do
 
         context "when middle false" do
           before do
-            Typhoeus.before { |r| String.new(r.url) }
-            Typhoeus.before { |r| String.new(r.url); nil }
-            Typhoeus.before { |r| String.new(r.url) }
+            Typhoeus.before { |r| String.new(r.base_url) }
+            Typhoeus.before { |r| String.new(r.base_url); nil }
+            Typhoeus.before { |r| String.new(r.base_url) }
           end
 
           it "doesn't call super" do

--- a/spec/typhoeus/request/block_connection_spec.rb
+++ b/spec/typhoeus/request/block_connection_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe Typhoeus::Request::BlockConnection do
-  let(:url) { "localhost:3001" }
-  let(:request) { Typhoeus::Request.new(url, {:method => :get}) }
+  let(:base_url) { "localhost:3001" }
+  let(:request) { Typhoeus::Request.new(base_url, {:method => :get}) }
 
   describe "run" do
     context "when blocked" do

--- a/spec/typhoeus/request/marshal_spec.rb
+++ b/spec/typhoeus/request/marshal_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
 describe Typhoeus::Request::Marshal do
-  let(:url) { "localhost:3001" }
-  let(:request) { Typhoeus::Request.new(url) }
+  let(:base_url) { "localhost:3001" }
+  let(:request) { Typhoeus::Request.new(base_url) }
 
   describe "#marshal_dump" do
-    let(:url) { "http://www.google.com" }
+    let(:base_url) { "http://www.google.com" }
 
     ['on_complete'].each do |name|
       context "when #{name} handler" do
@@ -22,8 +22,8 @@ describe Typhoeus::Request::Marshal do
         context "when loading" do
           let(:loaded) { Marshal.load(Marshal.dump(request)) }
 
-          it "includes url" do
-            expect(loaded.url).to eq(request.url)
+          it "includes base_url" do
+            expect(loaded.base_url).to eq(request.base_url)
           end
 
           it "doesn't include #{name}" do

--- a/spec/typhoeus/request/operations_spec.rb
+++ b/spec/typhoeus/request/operations_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe Typhoeus::Request::Operations do
-  let(:url) { "localhost:3001" }
+  let(:base_url) { "localhost:3001" }
   let(:options) { {} }
-  let(:request) { Typhoeus::Request.new(url, options) }
+  let(:request) { Typhoeus::Request.new(base_url, options) }
 
   describe "#run" do
     let(:easy) { Ethon::Easy.new }

--- a/spec/typhoeus/request/responseable_spec.rb
+++ b/spec/typhoeus/request/responseable_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Typhoeus::Request::Responseable do
-  let(:request) { Typhoeus::Request.new("url", {}) }
+  let(:request) { Typhoeus::Request.new("base_url", {}) }
   let(:response) { Typhoeus::Response.new }
 
   describe "#response=" do

--- a/spec/typhoeus/request/stubbable_spec.rb
+++ b/spec/typhoeus/request/stubbable_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
 describe Typhoeus::Request::Stubbable do
-  let(:url) { "localhost:3001" }
-  let(:request) { Typhoeus::Request.new(url) }
+  let(:base_url) { "localhost:3001" }
+  let(:request) { Typhoeus::Request.new(base_url) }
   let(:response) { Typhoeus::Response.new }
 
-  before { Typhoeus.stub(url).and_return(response) }
+  before { Typhoeus.stub(base_url).and_return(response) }
   after { Typhoeus::Expectation.clear }
 
   describe "#queue" do

--- a/spec/typhoeus/request_spec.rb
+++ b/spec/typhoeus/request_spec.rb
@@ -1,13 +1,19 @@
 require 'spec_helper'
 
 describe Typhoeus::Request do
-  let(:url) { "localhost:3001" }
+  let(:base_url) { "localhost:3001" }
   let(:options) { {:verbose => true, :headers => { 'User-Agent' => "Fubar" }} }
-  let(:request) { Typhoeus::Request.new(url, options) }
+  let(:request) { Typhoeus::Request.new(base_url, options) }
 
+  describe ".url" do
+    it "should be equal to base_url" do
+      expect(request.base_url).to eq(request.url)
+    end
+  end
+    
   describe ".new" do
-    it "stores url" do
-      expect(request.url).to eq(url)
+    it "stores base_url" do
+      expect(request.base_url).to eq(base_url)
     end
 
     it "stores options" do
@@ -50,16 +56,16 @@ describe Typhoeus::Request do
     end
 
     context "when same class" do
-      let(:other) { Typhoeus::Request.new("url", options) }
+      let(:other) { Typhoeus::Request.new("base_url", options) }
 
-      context "when other url" do
+      context "when other base_url" do
         it "returns false" do
           expect(request).to_not eql other
         end
       end
 
-      context "when same url and other options" do
-        let(:other) { Typhoeus::Request.new(url, {}) }
+      context "when same base_url and other options" do
+        let(:other) { Typhoeus::Request.new(base_url, {}) }
 
         it "returns false" do
           expect(request).to_not eql other
@@ -67,9 +73,9 @@ describe Typhoeus::Request do
       end
 
 
-      context "when same url and options" do
+      context "when same base_url and options" do
         context "when same order" do
-          let(:other) { Typhoeus::Request.new(url, options) }
+          let(:other) { Typhoeus::Request.new(base_url, options) }
 
           it "returns true" do
             expect(request).to eql other
@@ -78,7 +84,7 @@ describe Typhoeus::Request do
 
         context "when different order" do
           let(:other_options) { {:headers => { 'User-Agent' => "Fubar",  }, :verbose => true } }
-          let(:other) { Typhoeus::Request.new(url, other_options)}
+          let(:other) { Typhoeus::Request.new(base_url, other_options)}
 
           it "returns true" do
             expect(request).to eql other
@@ -90,7 +96,7 @@ describe Typhoeus::Request do
 
   describe "#hash" do
     context "when request.eql?(other)" do
-      let(:other) { Typhoeus::Request.new(url, options) }
+      let(:other) { Typhoeus::Request.new(base_url, options) }
 
       it "has same hashes" do
         expect(request.hash).to eq(other.hash)
@@ -98,7 +104,7 @@ describe Typhoeus::Request do
     end
 
     context "when not request.eql?(other)" do
-      let(:other) { Typhoeus::Request.new("url", {}) }
+      let(:other) { Typhoeus::Request.new("base_url", {}) }
 
       it "has different hashes" do
         expect(request.hash).to_not eq(other.hash)

--- a/spec/typhoeus_spec.rb
+++ b/spec/typhoeus_spec.rb
@@ -19,12 +19,12 @@ describe Typhoeus do
   end
 
   describe ".stub" do
-    let(:url) { "www.example.com" }
+    let(:base_url) { "www.example.com" }
     before { Typhoeus::Expectation.clear }
 
     context "when no similar expectation exists" do
       it "returns expectation" do
-        expect(Typhoeus.stub(url)).to be_a(Typhoeus::Expectation)
+        expect(Typhoeus.stub(base_url)).to be_a(Typhoeus::Expectation)
       end
 
       it "adds expectation" do
@@ -34,15 +34,15 @@ describe Typhoeus do
     end
 
     context "when similar expectation exists" do
-      let(:expectation) { Typhoeus::Expectation.new(url) }
+      let(:expectation) { Typhoeus::Expectation.new(base_url) }
       before { Typhoeus::Expectation.all << expectation }
 
       it "returns expectation" do
-        expect(Typhoeus.stub(url)).to be_a(Typhoeus::Expectation)
+        expect(Typhoeus.stub(base_url)).to be_a(Typhoeus::Expectation)
       end
 
       it "doesn't add expectation" do
-        Typhoeus.stub(url)
+        Typhoeus.stub(base_url)
         expect(Typhoeus::Expectation.all).to have(1).item
       end
     end

--- a/test.rb
+++ b/test.rb
@@ -27,8 +27,8 @@ Typhoeus.configure do |config|
   config.verbose = false
 end
 
-def get_my_request url, forbid_reuse_val, &block
-  request = Typhoeus::Request.new(url, forbid_reuse: forbid_reuse_val)
+def get_my_request base_url, forbid_reuse_val, &block
+  request = Typhoeus::Request.new(base_url, forbid_reuse: forbid_reuse_val)
   request.on_complete { |response| yield response } if block
   request
 end
@@ -78,8 +78,8 @@ j = 1
   multi_requests_two.run
 
   single_requests_per_iteration.times do |k|
-    url = "http://www.google.com/#q=stiff#{j+k}"
-    request = get_my_request url, forbid_reuse_val  do |response|
+    base_url = "http://www.google.com/#q=stiff#{j+k}"
+    request = get_my_request base_url, forbid_reuse_val  do |response|
       puts "----------------------#{response.body.length} #{response.request.url}"
     end
     puts "running single_requests #{j} #{k}"


### PR DESCRIPTION
@i0rek This renames url to base_url in almost every instance. I did not change it for Faraday as I was unsure of those implications. I added a .url method to Tyhoeus::Request, which returns base_url, and which I will build off of to implement the parameters again in a future pull request. Let me know what you think.
