### PR TITLE
Support default_proc behavior in Ruby 1.8.x

### DIFF
--- a/lib/typhoeus/response/header.rb
+++ b/lib/typhoeus/response/header.rb
@@ -17,9 +17,7 @@ module Typhoeus
         @raw = raw
         @sanitized = {}
         parse
-        self.default_proc = Proc.new do |h, k|
-          @sanitized[k.downcase]
-        end
+        set_default_proc_on(self, lambda { |h, k| @sanitized[k.downcase] })
       end
 
       # Parses the raw header.
@@ -78,6 +76,17 @@ module Typhoeus
       # @return [ String ] The raw header.
       def raw
         @raw || ''
+      end
+      
+      # Sets the default proc for the specified hash independent of the Ruby version.
+      #
+      # @return [ void ]
+      def set_default_proc_on(hash, default_proc)
+        if hash.respond_to?(:default_proc=)
+          hash.default_proc = default_proc
+        else
+          hash.replace(Hash.new(&default_proc).merge(hash))
+        end
       end
     end
   end


### PR DESCRIPTION
Added `set_default_proc_on` to `header.rb` for setting the default proc on a hash regardless of Ruby version.

See here for context:
https://github.com/typhoeus/typhoeus/issues/227#issuecomment-12106819

Cheers.
