### PR TITLE
Return response when before hook returns falsy

### DIFF
--- a/lib/typhoeus/request/before.rb
+++ b/lib/typhoeus/request/before.rb
@@ -20,7 +20,7 @@ module Typhoeus
         Typhoeus.before.each do |callback|
           value = callback.call(self)
           if value.nil? || value == false || value.is_a?(Response)
-            return value
+            return response
           end
         end
         super


### PR DESCRIPTION
I'm using Typhoeus 0.5.4 and Webmock 1.9.0. When I do something like this:

``` ruby
stub_request(:get, 'http://www.example.com')
response = Typhoeus.get('http://www.example.com')
```

Then `response` is `false` instead of the response like one would expect.

This is because when a before hook returns a falsy value, then that falsy value is returned. Webmock does not return a response in its hook (but sets it with finish), but just returns false (https://github.com/bblimke/webmock/blob/master/lib/webmock/http_lib_adapters/typhoeus_hydra_adapter.rb#L148), resulting in this scenario.

In this pull request I changed the hook system to return the response of the request instead of the hook return value (when falsy). This way the typhoeus API will never behave in an unexpected way.
