### PR TITLE
Implemented Response#handled_response

### DIFF
--- a/lib/typhoeus/response.rb
+++ b/lib/typhoeus/response.rb
@@ -54,5 +54,15 @@ module Typhoeus
     def mock
       defined?(@mock) ? @mock : options[:mock]
     end
+
+    # Returns the handled_response if it has 
+    # been defined otherwise returns the response
+    #
+    # @return [ Typhoeus::Response ] The result of callbacks 
+    # done on the response or the current response if no 
+    # callbacks were called
+    def handled_response
+      @handled_response || self
+    end
   end
 end

--- a/spec/typhoeus/response_spec.rb
+++ b/spec/typhoeus/response_spec.rb
@@ -58,4 +58,24 @@ describe Typhoeus::Response do
       end
     end
   end
+
+  describe "#handled_response" do
+    let(:handled_response) { Typhoeus::Response.new }
+
+    context "when @handled_response" do
+      before { response.handled_response = handled_response }
+
+      it "returns @handled_response" do
+        expect(response.handled_response).to be(handled_response)
+      end
+    end
+
+    context "when @handled_response is nil" do
+      before { response.handled_response = nil }
+
+      it "returns response" do
+        expect(response.handled_response).to be(response)
+      end
+    end
+  end
 end


### PR DESCRIPTION
In Typhoeus pre-0.5.0, there was a method on request that for the handled_response would return the handled_response if it had been set otherwise would return the response

https://github.com/typhoeus/typhoeus/blob/v0.4.2/lib/typhoeus/request.rb#L185

After handled_response was returned in the Typhoeus::Response object in 0.5.4, a similiar method to the method mentioned above was not returned as well. This puts the handled_response method into Typhoeus::Response with a similar implementation.
