### PR TITLE
Printing the request url when no stub error occurrs

### DIFF
--- a/lib/typhoeus/errors/no_stub.rb
+++ b/lib/typhoeus/errors/no_stub.rb
@@ -5,7 +5,7 @@ module Typhoeus
     # and making a real request.
     class NoStub < TyphoeusError
       def initialize(request)
-        super("The connection is blocked and no stub defined.")
+        super("The connection is blocked and no stub defined: #{request.url}")
       end
     end
   end

--- a/spec/typhoeus/errors/no_stub_spec.rb
+++ b/spec/typhoeus/errors/no_stub_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Typhoeus::Errors::NoStub do
+  let(:base_url) { "localhost:3001" }
+  let(:options) { {:verbose => true, :headers => { 'User-Agent' => "Fubar" }} }
+  let(:request) { Typhoeus::Request.new(base_url, options) }
+  let(:message) { "The connection is blocked and no stub defined: " }
+
+  subject { Typhoeus::Errors::NoStub }
+
+  it "displays the request url" do
+    expect { raise subject.new(request) }.to raise_error(subject, message + base_url)
+  end
+end


### PR DESCRIPTION
I added the request url to the message of a No Stub exception. It's now easier to figure out where a No Stub error originates.
