### PR TITLE
Return the easy object back to the pool in Typhoeus::Request#url

### DIFF
--- a/lib/typhoeus/request.rb
+++ b/lib/typhoeus/request.rb
@@ -123,7 +123,10 @@ module Typhoeus
     #
     # @since 0.5.5
     def url
-      EasyFactory.new(self).get.url
+      easy = EasyFactory.new(self).get
+      url = easy.url
+      Typhoeus::Pool.release(easy)
+      url
     end
 
     # Returns whether other is equal to self.

--- a/spec/typhoeus/request_spec.rb
+++ b/spec/typhoeus/request_spec.rb
@@ -19,6 +19,13 @@ describe Typhoeus::Request do
         expect(request.url).to eq("#{request.base_url}?a=1")
       end
     end
+
+    it "pushes an easy back into the pool" do
+      easy = mock.as_null_object
+      Typhoeus::Pool.stub(:get).and_return(easy)
+      Typhoeus::Pool.should_receive(:release).with(easy)
+      request.url
+    end
   end
 
   describe ".new" do


### PR DESCRIPTION
Typhoeus::Request.url pulls an easy instance from Typhoeus::Pool via EasyFactory.new.get. This easy instance is temporary and is never used to make a request. The completion callback is not run and, therefore, the easy instance is never returned to the pool.
