### PR TITLE
Updating marshal to exclude on_success and on_failure

### DIFF
--- a/lib/typhoeus/request/marshal.rb
+++ b/lib/typhoeus/request/marshal.rb
@@ -5,9 +5,10 @@ module Typhoeus
     module Marshal
 
       # Return the important data needed to serialize this Request, except the
-      # `on_complete` handler, since they cannot be marshalled.
+      # `on_complete`, `on_success`, and `on_failure` handlers, since they cannot be marshalled.
       def marshal_dump
-        (instance_variables - ['@on_complete', :@on_complete]).map do |name|
+        callbacks = %w(@on_complete @on_success @on_failure)
+        (instance_variables - callbacks - callbacks.map(&:to_sym)).map do |name|
           [name, instance_variable_get(name)]
         end
       end

--- a/spec/typhoeus/request/marshal_spec.rb
+++ b/spec/typhoeus/request/marshal_spec.rb
@@ -7,7 +7,7 @@ describe Typhoeus::Request::Marshal do
   describe "#marshal_dump" do
     let(:base_url) { "http://www.google.com" }
 
-    ['on_complete'].each do |name|
+    %w(on_complete on_success on_failure).each do |name|
       context "when #{name} handler" do
         before { request.instance_variable_set("@#{name}", Proc.new{}) }
 


### PR DESCRIPTION
Mashalling a `Typhoeus::Request` instance fails if there is a `on_success` or a `on_failure` callback defined. I updated the `Marshal` module to also exclude these handlers.

To reproduce the error:

``` ruby
> request = Typhoeus::Request.new('http://www.google.com')
> request.on_success { }
> Marshal.dump(request)
=> TypeError: no marshal_dump is defined for class Proc
```
