### PR TITLE
Updating marshal to exclude hydra

### DIFF
--- a/lib/typhoeus/request/marshal.rb
+++ b/lib/typhoeus/request/marshal.rb
@@ -5,10 +5,10 @@ module Typhoeus
     module Marshal
 
       # Return the important data needed to serialize this Request, except the
-      # `on_complete`, `on_success`, and `on_failure` handlers, since they cannot be marshalled.
+      # `on_complete`, `on_success`, `on_failure`, and `hydra`, since they cannot be marshalled.
       def marshal_dump
-        callbacks = %w(@on_complete @on_success @on_failure)
-        (instance_variables - callbacks - callbacks.map(&:to_sym)).map do |name|
+        unmarshallable = %w(@on_complete @on_success @on_failure @hydra)
+        (instance_variables - unmarshallable - unmarshallable.map(&:to_sym)).map do |name|
           [name, instance_variable_get(name)]
         end
       end

--- a/spec/typhoeus/request/marshal_spec.rb
+++ b/spec/typhoeus/request/marshal_spec.rb
@@ -32,5 +32,31 @@ describe Typhoeus::Request::Marshal do
         end
       end
     end
+
+    context 'when run through hydra' do
+      let(:options) { {} }
+      let(:hydra) { Typhoeus::Hydra.new(options) }
+
+      before(:each) do
+        hydra.queue(request)
+        hydra.run
+      end
+
+      it "doesn't include @hydra" do
+        expect(request.send(:marshal_dump).map(&:first)).to_not include("@hydra")
+      end
+
+      context 'when loading' do
+        let(:loaded) { Marshal.load(Marshal.dump(request)) }
+
+        it "includes base_url" do
+          expect(loaded.base_url).to eq(request.base_url)
+        end
+
+        it "doesn't include #{name}" do
+          expect(loaded.instance_variables).to_not include("@hydra")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Mashalling a `Typhoeus::Request` instance fails if the request was performed through hydra. Hydra's @multi could not be marshalled so I just removed @hydra altogether from the request when marshalling.

To reproduce the error:

``` ruby
> hydra = Typhoeus::Hydra.new
> request = Typhoeus::Request.new('http://www.google.com')
> hydra.queue(request)
> hydra.run
> Marshal.dump(request)
=> TypeError: no marshal_dump is defined for class FFI::MemoryPointer
```
