### PR TITLE
Added important line to the documentation on 'request callbacks' in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ request.on_complete do |response|
     log("HTTP request failed: " + response.code.to_s)
   end
 end
+request.execute_callbacks
 ```
 
 This also works with serial (blocking) requests in the same fashion. Both


### PR DESCRIPTION
note the line 108 'end', should be followed by the all important --> request.execute_callbacks.
This has now been added.
