### PR TITLE
README: rename deprecated method name to current one

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ request.on_complete do |response|
     log("got a time out")
   elsif response.code == 0
     # Could not get an http response, something's wrong.
-    log(response.curl_error_message)
+    log(response.return_message)
   else
     # Received a non-successful http response.
     log("HTTP request failed: " + response.code.to_s)


### PR DESCRIPTION
Just a small thing I stumbled on. In the README is still a deprecated method name, namely `curl_error_message` on the `response` object. This commit replaces it with the current one: `return_message`.
