### PR TITLE
Request#hash: No need to calculate an MD5 hash

### DIFF
--- a/lib/typhoeus/request.rb
+++ b/lib/typhoeus/request.rb
@@ -1,3 +1,4 @@
+require 'zlib'
 require 'typhoeus/request/actions'
 require 'typhoeus/request/before'
 require 'typhoeus/request/block_connection'
@@ -151,7 +152,7 @@ module Typhoeus
     #
     # @api private
     def hash
-      "#{self.class.name}#{base_url}#{options}".hash
+      Zlib.crc32 "#{self.class.name}#{base_url}#{options}"
     end
 
     private


### PR DESCRIPTION
Calling `#hash` on the seed has the same effect without the extra MD5 overhead.
