### PR TITLE
Add option to pass from Faraday to Ethon a ssl client certificate passwo...

### DIFF
--- a/lib/typhoeus/adapters/faraday.rb
+++ b/lib/typhoeus/adapters/faraday.rb
@@ -120,6 +120,7 @@ module Faraday # :nodoc:
         req.options[:sslkey]     = ssl[:client_key]  if ssl[:client_key]
         req.options[:cainfo]     = ssl[:ca_file]     if ssl[:ca_file]
         req.options[:capath]     = ssl[:ca_path]     if ssl[:ca_path]
+        req.options[:keypasswd]  = ssl[:client_cert_passwd] if ssl[:client_cert_passwd]
       end
 
       def configure_proxy(req, env)


### PR DESCRIPTION
...rd

When trying to use a ssl client certificate, a password must be given. The added line of code allows to pass the client_cert_password (to follow the client_cert option naming)
