### PR TITLE
add guard on return_message

### DIFF
--- a/lib/typhoeus/response/informations.rb
+++ b/lib/typhoeus/response/informations.rb
@@ -24,7 +24,7 @@ module Typhoeus
       #
       # @since 0.6.2
       def return_message
-        Ethon::Curl.easy_strerror(return_code)
+        Ethon::Curl.easy_strerror(return_code) if return_code
       end
 
       # Return the http response body.

--- a/spec/typhoeus/response/informations_spec.rb
+++ b/spec/typhoeus/response/informations_spec.rb
@@ -26,6 +26,14 @@ describe Typhoeus::Response::Informations do
     it "returns a message" do
       expect(response.return_message).to eq("Couldn't connect to server")
     end
+
+    describe "with nil return_code" do
+      let(:options) { { :return_code => nil } }
+
+      it "returns nil" do
+        expect(response.return_message).to be_nil
+      end
+    end
   end
 
   describe "#response_body" do


### PR DESCRIPTION
So I had some specs in my code where I logged the return message. It gives me an error:
TypeError: no implicit conversion from nil to integer

the reason is that when stubbing typhoeus there is no return_code, so return_message fails.

This PR adds a check to use the return_code only if it exists
