### PR TITLE
Faraday follows Ruby's URI and calls this field :user and not :username

### DIFF
--- a/lib/typhoeus/adapters/faraday.rb
+++ b/lib/typhoeus/adapters/faraday.rb
@@ -128,7 +128,7 @@ module Faraday # :nodoc:
 
         req.options[:proxy] = "#{proxy[:uri].host}:#{proxy[:uri].port}"
 
-        if proxy[:username] && proxy[:password]
+        if proxy[:user] && proxy[:password]
           req.options[:proxyuserpwd] = "#{proxy[:username]}:#{proxy[:password]}"
         end
       end


### PR DESCRIPTION
This one change, allows proxies with authentication required, to function without having to specify both `:user` and `:username` in Faraday proxy options hash
