### PR TITLE
Added queue_front to Typhoeus::Hydra::Queueable

### DIFF
--- a/lib/typhoeus/hydra/queueable.rb
+++ b/lib/typhoeus/hydra/queueable.rb
@@ -40,6 +40,17 @@ module Typhoeus
         queued_requests << request
       end
 
+      # Pushes a request to the front of the queue,
+      # to be performed by the hydra. Also sets hydra
+      # on request
+      #
+      # @example Queue reques.
+      #   hydra.queue_front(request)
+      def queue_front(request)
+        request.hydra = self
+        queued_requests.unshift request
+      end
+
       # Removes a request from queued_requests and
       # adds it to the hydra in order to be
       # performed next.

--- a/spec/typhoeus/hydra/queueable_spec.rb
+++ b/spec/typhoeus/hydra/queueable_spec.rb
@@ -21,6 +21,11 @@ describe Typhoeus::Hydra::Queueable do
       hydra.queue(request)
       expect(hydra.queued_requests).to include(request)
     end
+    
+    it "adds to front of queued requests" do 
+      hydra.queue_front(request)
+      expect(hydra.queued_requests.first).to be(request)
+    end
   end
 
   describe "#abort" do


### PR DESCRIPTION
This adds a queue_front method to Typhoeus::Hydra::Queueable, which pushes a request to the front of the request queue.

This allows for psuedo-recursive request fetching, as new requests can be generated and pushed to the front queue, then executed on the next cycle, instead of at the end.
