### PR TITLE
Check the response headers for the response_code if not passed into the ...

### DIFF
--- a/lib/typhoeus/response/informations.rb
+++ b/lib/typhoeus/response/informations.rb
@@ -53,20 +53,6 @@ module Typhoeus
         end
       end
 
-      # Return the last received HTTP, FTP or SMTP response code.
-      # The value will be zero if no server response code has
-      # been received. Note that a proxy's CONNECT response should
-      # be read with http_connect_code and not this.
-      #
-      # @example Get response_code.
-      #   response.response_code
-      #
-      # @return [ Integer ] The response_code.
-      def response_code
-        (options[:response_code] || options[:code]).to_i
-      end
-      alias :code :response_code
-
       # Return the available http auth methods.
       # Bitmask indicating the authentication method(s)
       # available.

--- a/lib/typhoeus/response/status.rb
+++ b/lib/typhoeus/response/status.rb
@@ -5,6 +5,27 @@ module Typhoeus
     # status.
     module Status
 
+      # Return the last received HTTP, FTP or SMTP response code.
+      # The value will be zero if no server response code has
+      # been received. Note that a proxy's CONNECT response should
+      # be read with http_connect_code and not this.
+      #
+      # @example Get response_code.
+      #   response.response_code
+      #
+      # @return [ Integer ] The response_code.
+      def response_code
+        return @response_code if defined?(@response_code) && @response_code
+        return (options[:response_code] || options[:code]).to_i unless (options[:response_code] || options[:code]).nil?
+
+        if first_header_line != nil and first_header_line[/HTTP\/\S+ (\d{3})(?:$| )/, 1] != nil
+          @response_code = first_header_line[/HTTP\/\S+ (\d{3})(?:$| )/, 1].to_i
+        else
+          @response_code = 0
+        end
+      end
+      alias :code :response_code
+
       # Return the status message if present.
       #
       # @example Return status message.

--- a/spec/typhoeus/response/informations_spec.rb
+++ b/spec/typhoeus/response/informations_spec.rb
@@ -76,24 +76,6 @@ describe Typhoeus::Response::Informations do
     end
   end
 
-  describe "#response_code" do
-    context "when response_code" do
-      let(:options) { { :response_code => "200" } }
-
-      it "returns response_code from options" do
-        expect(response.response_code).to eq(200)
-      end
-    end
-
-    context "when code" do
-      let(:options) { { :code => "200" } }
-
-      it "returns code from options" do
-        expect(response.code).to eq(200)
-      end
-    end
-  end
-
   describe "#httpauth_avail" do
     let(:options) { { :httpauth_avail => "code" } }
 

--- a/spec/typhoeus/response/status_spec.rb
+++ b/spec/typhoeus/response/status_spec.rb
@@ -30,6 +30,40 @@ describe Typhoeus::Response::Status do
     end
   end
 
+  describe "#response_code" do
+    context "when response_code" do
+      let(:options) { { :response_code => "200" } }
+
+      it "returns response_code from options" do
+        expect(response.response_code).to eq(200)
+      end
+    end
+
+    context "when code" do
+      let(:options) { { :code => "200" } }
+
+      it "returns code from options" do
+        expect(response.code).to eq(200)
+      end
+    end
+
+    context "when the option isn't set but the header is" do
+      context "and has a status message" do
+        let(:options) { { :response_headers => "HTTP/1.1 200 OK" } }
+        it "returns response_code from headers" do
+          expect(response.response_code).to eq(200)
+        end
+      end
+
+      context "and does not have a status message" do
+        let(:options) { { :response_headers => "HTTP/1.1 200" } }
+        it "returns response_code from headers" do
+          expect(response.response_code).to eq(200)
+        end
+      end
+    end
+  end
+
   describe "#status_message" do
     context "when no header" do
       it "returns nil" do


### PR DESCRIPTION
...options.

Currently, when you call `response.redirections`, you get an array of responses with the response_headers set properly, but not response code set on any of them. This pull request fixes that issue by checking the headers for the response code if the option isn't set, similar to `#status_message`
