### PR TITLE
Headers should have "\r\n" between each line according to the RFC.

### DIFF
--- a/lib/typhoeus/response/informations.rb
+++ b/lib/typhoeus/response/informations.rb
@@ -49,7 +49,7 @@ module Typhoeus
         if mock? && h = options[:headers]
             h.map{ |k,v| [k, v.respond_to?(:join) ? v.join : v] }.
               map{ |e| "#{e.first}: #{e.last}" }.
-              join("\n")
+              join("\r\n")
         end
       end
 

--- a/spec/typhoeus/adapters/faraday_spec.rb
+++ b/spec/typhoeus/adapters/faraday_spec.rb
@@ -40,7 +40,7 @@ describe Faraday::Adapter::Typhoeus do
     before do
       stub = Typhoeus::Response.new \
         :code    => 200,
-        :headers => { "Foo" => "Bar" },
+        :headers => { "Foo" => "2", "Bar" => "3" },
         :body    => "Hello",
         :mock    => true
 
@@ -56,7 +56,7 @@ describe Faraday::Adapter::Typhoeus do
     end
 
     it 'stubs the headers' do
-      expect(response.headers).to eq("Foo" => "Bar")
+      expect(response.headers).to eq("Foo" => "2", "Bar" => "3")
     end
   end
 

--- a/spec/typhoeus/response/informations_spec.rb
+++ b/spec/typhoeus/response/informations_spec.rb
@@ -66,10 +66,10 @@ describe Typhoeus::Response::Informations do
     context "when mock" do
       context "when no response_headers" do
         context "when headers" do
-          let(:options) { { :mock => true, :headers => {"Length" => 1 } } }
+          let(:options) { { :mock => true, :headers => {"Length" => 1, "Content-Type" => "text/plain" } } }
 
           it "constructs response_headers" do
-            expect(response.response_headers).to eq("Length: 1")
+            expect(response.response_headers).to eq("Length: 1\r\nContent-Type: text/plain")
           end
         end
       end


### PR DESCRIPTION
Without the "\r", this was causing a second header to
be collapsed into the first value. The existing tests
didn't catch this case because it only stubbed one
header key/value pair.
