### PR TITLE
Adding note about clearing stubs between tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Typhoeus.get("www.example.com") == response
 #=> true
 ```
 
-When testing make sure to clear your expectations between tests as the stubs will persist between tests. An example in rspec is below.
+When testing make sure to clear your expectations or the stubs will persist between tests. The following can be included in your spec_helper.rb file to do this automatically.
 
 ```ruby
 RSpec.configure do |config|


### PR DESCRIPTION
While testing an application I ran into some odd behavior where stubs were not being cleared between tests automatically. Additionally if I redefined the same stub that had already been defined I'd get the old behavior. I wanted to provide an addition to the documentation so it was clear for others so they didn't fall into the same trap as I did.

Demo of the behavior
https://gist.github.com/pcorliss/7832781
