### PR TITLE
Ensure the Easy http request gets a String uri.

### DIFF
--- a/lib/typhoeus/easy_factory.rb
+++ b/lib/typhoeus/easy_factory.rb
@@ -49,7 +49,7 @@ module Typhoeus
     def get
       begin
         easy.http_request(
-          request.base_url,
+          request.base_url.to_s,
           request.options.fetch(:method, :get),
           sanitize(request.options)
         )


### PR DESCRIPTION
This allows passing `URI` or `Addressable::URI` instances into the `Typoeus::Request`.
