### PR TITLE
Convert specs to RSpec expect syntax with transpec

### DIFF
--- a/spec/rack/typhoeus/middleware/params_decoder_spec.rb
+++ b/spec/rack/typhoeus/middleware/params_decoder_spec.rb
@@ -7,11 +7,11 @@ describe "Rack::Typhoeus::Middleware::ParamsDecoder" do
   end
 
   let(:app) do
-    stub
+    double
   end
 
   let(:env) do
-    stub
+    double
   end
 
   let(:klass) do

--- a/spec/typhoeus/adapters/faraday_spec.rb
+++ b/spec/typhoeus/adapters/faraday_spec.rb
@@ -84,7 +84,7 @@ describe Faraday::Adapter::Typhoeus do
         let(:env) { { :method => :get, :ssl => {}, :request => {} } }
 
         it "falls back to single" do
-          Typhoeus::Request.should_receive(:new).and_return(double(:options => {}, :on_complete => [], :run => true))
+          expect(Typhoeus::Request).to receive(:new).and_return(double(:options => {}, :on_complete => [], :run => true))
           adapter.method(:perform_request).call(env)
         end
       end
@@ -119,7 +119,7 @@ describe Faraday::Adapter::Typhoeus do
     end
 
     it "sets on_complete callback" do
-      expect(request.on_complete).to have(1).items
+      expect(request.on_complete.size).to eq(1)
     end
   end
 

--- a/spec/typhoeus/easy_factory_spec.rb
+++ b/spec/typhoeus/easy_factory_spec.rb
@@ -48,15 +48,15 @@ describe Typhoeus::EasyFactory do
       let(:options) { {:connect_timeout => 1} }
 
       it "warns" do
-        easy_factory.should_receive(:warn).with(
+        expect(easy_factory).to receive(:warn).with(
           "Deprecated option connect_timeout. Please use connecttimeout instead."
         )
         easy_factory.get
       end
 
       it "passes correct option" do
-        easy_factory.should_receive(:warn)
-        easy_factory.easy.should_receive(:connecttimeout=).with(1)
+        expect(easy_factory).to receive(:warn)
+        expect(easy_factory.easy).to receive(:connecttimeout=).with(1)
         easy_factory.get
       end
     end
@@ -64,19 +64,19 @@ describe Typhoeus::EasyFactory do
 
   describe "#set_callback" do
     it "sets easy.on_complete callback" do
-      easy_factory.easy.should_receive(:on_complete)
+      expect(easy_factory.easy).to receive(:on_complete)
       easy_factory.send(:set_callback)
     end
 
     it "finishes request" do
       easy_factory.send(:set_callback)
-      request.should_receive(:finish)
+      expect(request).to receive(:finish)
       easy_factory.easy.complete
     end
 
     it "resets easy" do
       easy_factory.send(:set_callback)
-      easy_factory.easy.should_receive(:reset)
+      expect(easy_factory.easy).to receive(:reset)
       easy_factory.easy.complete
     end
 
@@ -88,7 +88,7 @@ describe Typhoeus::EasyFactory do
 
     it "adds next request" do
       easy_factory.hydra.instance_variable_set(:@queued_requests, [request])
-      easy_factory.hydra.should_receive(:add).with(request)
+      expect(easy_factory.hydra).to receive(:add).with(request)
       easy_factory.send(:set_callback)
       easy_factory.easy.complete
     end

--- a/spec/typhoeus/expectation_spec.rb
+++ b/spec/typhoeus/expectation_spec.rb
@@ -40,7 +40,7 @@ describe Typhoeus::Expectation do
     let(:expectations) { double(:clear) }
 
     it "clears all" do
-      expectations.should_receive(:clear)
+      expect(expectations).to receive(:clear)
       Typhoeus::Expectation.instance_variable_set(:@expectations, expectations)
       Typhoeus::Expectation.clear
       Typhoeus::Expectation.instance_variable_set(:@expectations, nil)
@@ -53,8 +53,8 @@ describe Typhoeus::Expectation do
 
     it "finds a matching expectation and returns its next response" do
       Typhoeus::Expectation.all << expectation
-      expectation.should_receive(:matches?).with(request).and_return(true)
-      expectation.should_receive(:response).with(request).and_return(stubbed_response)
+      expect(expectation).to receive(:matches?).with(request).and_return(true)
+      expect(expectation).to receive(:response).with(request).and_return(stubbed_response)
 
       response = Typhoeus::Expectation.response_for(request)
 
@@ -154,13 +154,13 @@ describe Typhoeus::Expectation do
     let(:request) { double(:base_url => nil) }
 
     it "calls url_match?" do
-      expectation.should_receive(:url_match?)
+      expect(expectation).to receive(:url_match?)
       expectation.matches?(request)
     end
 
     it "calls options_match?" do
-      expectation.should_receive(:url_match?).and_return(true)
-      expectation.should_receive(:options_match?)
+      expect(expectation).to receive(:url_match?).and_return(true)
+      expect(expectation).to receive(:options_match?)
       expectation.matches?(request)
     end
   end

--- a/spec/typhoeus/hydra/addable_spec.rb
+++ b/spec/typhoeus/hydra/addable_spec.rb
@@ -6,17 +6,17 @@ describe Typhoeus::Hydra::Addable do
 
   it "asks easy factory for an easy" do
     multi = double
-    Typhoeus::EasyFactory.should_receive(:new).with(request, hydra).and_return(double(:get => 1))
-    hydra.should_receive(:multi).and_return(multi)
-    multi.should_receive(:add).with(1)
+    expect(Typhoeus::EasyFactory).to receive(:new).with(request, hydra).and_return(double(:get => 1))
+    expect(hydra).to receive(:multi).and_return(multi)
+    expect(multi).to receive(:add).with(1)
     hydra.add(request)
   end
 
   it "adds easy to multi" do
     multi = double
-    Typhoeus::EasyFactory.should_receive(:new).with(request, hydra).and_return(double(:get => 1))
-    hydra.should_receive(:multi).and_return(multi)
-    multi.should_receive(:add).with(1)
+    expect(Typhoeus::EasyFactory).to receive(:new).with(request, hydra).and_return(double(:get => 1))
+    expect(hydra).to receive(:multi).and_return(multi)
+    expect(multi).to receive(:add).with(1)
     hydra.add(request)
   end
 end

--- a/spec/typhoeus/hydra/before_spec.rb
+++ b/spec/typhoeus/hydra/before_spec.rb
@@ -9,14 +9,14 @@ describe Typhoeus::Hydra::Before do
       context "when one" do
         it "executes" do
           Typhoeus.before { |r| String.new(r.base_url) }
-          String.should_receive(:new).and_return("")
+          expect(String).to receive(:new).and_return("")
           hydra.add(request)
         end
 
         context "when true" do
           it "calls super" do
             Typhoeus.before { true }
-            Typhoeus::Expectation.should_receive(:response_for)
+            expect(Typhoeus::Expectation).to receive(:response_for)
             hydra.add(request)
           end
         end
@@ -37,7 +37,7 @@ describe Typhoeus::Hydra::Before do
           context "when false" do
             it "doesn't call super" do
               Typhoeus.before { false }
-              Typhoeus::Expectation.should_receive(:response_for).never
+              expect(Typhoeus::Expectation).to receive(:response_for).never
               hydra.add(request)
             end
           end
@@ -45,7 +45,7 @@ describe Typhoeus::Hydra::Before do
           context "when response" do
             it "doesn't call super" do
               Typhoeus.before { Typhoeus::Response.new }
-              Typhoeus::Expectation.should_receive(:response_for).never
+              expect(Typhoeus::Expectation).to receive(:response_for).never
               hydra.add(request)
             end
           end
@@ -57,12 +57,12 @@ describe Typhoeus::Hydra::Before do
           before { 3.times { Typhoeus.before { |r| String.new(r.base_url) } } }
 
           it "calls super" do
-            Typhoeus::Expectation.should_receive(:response_for)
+            expect(Typhoeus::Expectation).to receive(:response_for)
             hydra.add(request)
           end
 
           it "executes all" do
-            String.should_receive(:new).exactly(3).times.and_return("")
+            expect(String).to receive(:new).exactly(3).times.and_return("")
             hydra.add(request)
           end
         end
@@ -75,12 +75,12 @@ describe Typhoeus::Hydra::Before do
           end
 
           it "doesn't call super" do
-            Typhoeus::Expectation.should_receive(:response_for).never
+            expect(Typhoeus::Expectation).to receive(:response_for).never
             hydra.add(request)
           end
 
           it "executes only two" do
-            String.should_receive(:new).exactly(2).times.and_return("")
+            expect(String).to receive(:new).exactly(2).times.and_return("")
             hydra.add(request)
           end
         end
@@ -89,7 +89,7 @@ describe Typhoeus::Hydra::Before do
 
     context "when no before" do
       it "calls super" do
-        Typhoeus::Expectation.should_receive(:response_for)
+        expect(Typhoeus::Expectation).to receive(:response_for)
         hydra.add(request)
       end
     end

--- a/spec/typhoeus/hydra/cacheable_spec.rb
+++ b/spec/typhoeus/hydra/cacheable_spec.rb
@@ -18,7 +18,7 @@ describe Typhoeus::Hydra::Cacheable do
         end
 
         it "doesn't call complete" do
-          request.should_receive(:complete).never
+          expect(request).to receive(:complete).never
           hydra.add(request)
         end
       end
@@ -34,7 +34,7 @@ describe Typhoeus::Hydra::Cacheable do
 
         context "when no queued requests" do
           it "finishes request" do
-            request.should_receive(:finish).with(response)
+            expect(request).to receive(:finish).with(response)
             hydra.add(request)
             expect(response.cached?).to be_true
           end
@@ -47,8 +47,8 @@ describe Typhoeus::Hydra::Cacheable do
 
           it "finishes both requests" do
             hydra.queue(queued_request)
-            request.should_receive(:finish).with(response)
-            queued_request.should_receive(:finish).with(response)
+            expect(request).to receive(:finish).with(response)
+            expect(queued_request).to receive(:finish).with(response)
             hydra.add(request)
           end
         end

--- a/spec/typhoeus/hydra/memoizable_spec.rb
+++ b/spec/typhoeus/hydra/memoizable_spec.rb
@@ -16,7 +16,7 @@ describe Typhoeus::Hydra::Memoizable do
         end
 
         it "doesn't call complete" do
-          request.should_receive(:complete).never
+          expect(request).to receive(:complete).never
           hydra.add(request)
         end
       end
@@ -26,7 +26,7 @@ describe Typhoeus::Hydra::Memoizable do
         before { hydra.memory[request] = response }
 
         it "finishes request" do
-          request.should_receive(:finish).with(response, true)
+          expect(request).to receive(:finish).with(response, true)
           hydra.add(request)
         end
 
@@ -35,8 +35,8 @@ describe Typhoeus::Hydra::Memoizable do
 
           it "dequeues" do
             hydra.queue(queued_request)
-            request.should_receive(:finish).with(response, true)
-            queued_request.should_receive(:finish).with(response, true)
+            expect(request).to receive(:finish).with(response, true)
+            expect(queued_request).to receive(:finish).with(response, true)
             hydra.add(request)
           end
         end
@@ -46,7 +46,7 @@ describe Typhoeus::Hydra::Memoizable do
 
   describe "#run" do
     it "clears memory before starting" do
-      hydra.memory.should_receive(:clear)
+      expect(hydra.memory).to receive(:clear)
       hydra.run
     end
   end

--- a/spec/typhoeus/hydra/runnable_spec.rb
+++ b/spec/typhoeus/hydra/runnable_spec.rb
@@ -14,7 +14,7 @@ describe Typhoeus::Hydra::Runnable do
       let(:requests) { [] }
 
       it "does nothing" do
-        hydra.multi.should_receive(:perform)
+        expect(hydra.multi).to receive(:perform)
         hydra.run
       end
     end
@@ -24,12 +24,12 @@ describe Typhoeus::Hydra::Runnable do
       let(:requests) { [first] }
 
       it "adds request from queue to multi" do
-        hydra.should_receive(:add).with(first)
+        expect(hydra).to receive(:add).with(first)
         hydra.run
       end
 
       it "runs multi#perform" do
-        hydra.multi.should_receive(:perform)
+        expect(hydra.multi).to receive(:perform)
         hydra.run
       end
 
@@ -46,14 +46,14 @@ describe Typhoeus::Hydra::Runnable do
       let(:requests) { [first, second, third] }
 
       it "adds requests from queue to multi" do
-        hydra.should_receive(:add).with(first)
-        hydra.should_receive(:add).with(second)
-        hydra.should_receive(:add).with(third)
+        expect(hydra).to receive(:add).with(first)
+        expect(hydra).to receive(:add).with(second)
+        expect(hydra).to receive(:add).with(third)
         hydra.run
       end
 
       it "runs multi#perform" do
-        hydra.multi.should_receive(:perform)
+        expect(hydra.multi).to receive(:perform)
         hydra.run
       end
 
@@ -134,7 +134,7 @@ describe Typhoeus::Hydra::Runnable do
           let(:options) { {} }
 
           it "calls on_complete callback once for every response" do
-            String.should_receive(:new).exactly(2).times
+            expect(String).to receive(:new).exactly(2).times
             hydra.run
           end
         end
@@ -145,7 +145,7 @@ describe Typhoeus::Hydra::Runnable do
           before { Typhoeus.before{ |request|  request.finish(Typhoeus::Response.new) } }
 
           it "simulates real multi run and adds and finishes both requests" do
-            String.should_receive(:new).exactly(2).times
+            expect(String).to receive(:new).exactly(2).times
             hydra.run
           end
         end

--- a/spec/typhoeus/hydra/stubbable_spec.rb
+++ b/spec/typhoeus/hydra/stubbable_spec.rb
@@ -15,7 +15,7 @@ describe Typhoeus::Hydra::Stubbable do
 
     context "when expectation found" do
       it "finishes response" do
-        request.should_receive(:finish)
+        expect(request).to receive(:finish)
         hydra.add(request)
       end
 

--- a/spec/typhoeus/hydra_spec.rb
+++ b/spec/typhoeus/hydra_spec.rb
@@ -9,7 +9,7 @@ describe Typhoeus::Hydra do
     let(:options) { {:pipeling => true} }
 
     it "passes options to multi" do
-      Ethon::Multi.should_receive(:new).with(options)
+      expect(Ethon::Multi).to receive(:new).with(options)
       hydra
     end
   end

--- a/spec/typhoeus/pool_spec.rb
+++ b/spec/typhoeus/pool_spec.rb
@@ -12,7 +12,7 @@ describe Typhoeus::Pool do
 
   describe "#release" do
     it "resets easy" do
-      easy.should_receive(:reset)
+      expect(easy).to receive(:reset)
       Typhoeus::Pool.release(easy)
     end
 
@@ -28,7 +28,7 @@ describe Typhoeus::Pool do
             Typhoeus::Pool.release(Ethon::Easy.new)
           end
         end.map(&:join)
-        expect(Typhoeus::Pool.send(:easies)).to have(10).easies
+        expect(Typhoeus::Pool.send(:easies).size).to eq(10)
       end
     end
   end
@@ -55,7 +55,7 @@ describe Typhoeus::Pool do
               array << Typhoeus::Pool.get
             end
           end.map(&:join)
-          expect(array.uniq).to have(10).easies
+          expect(array.uniq.size).to eq(10)
         end
       end
     end
@@ -73,7 +73,7 @@ describe Typhoeus::Pool do
           end
         end
       end
-      expect(array.uniq).to have(3).easies
+      expect(array.uniq.size).to eq(3)
     end
   end
 end

--- a/spec/typhoeus/request/before_spec.rb
+++ b/spec/typhoeus/request/before_spec.rb
@@ -8,14 +8,14 @@ describe Typhoeus::Request::Before do
       context "when one" do
         it "executes" do
           Typhoeus.before { |r| String.new(r.base_url) }
-          String.should_receive(:new).and_return("")
+          expect(String).to receive(:new).and_return("")
           request.run
         end
 
         context "when true" do
           it "calls super" do
             Typhoeus.before { true }
-            Typhoeus::Expectation.should_receive(:response_for)
+            expect(Typhoeus::Expectation).to receive(:response_for)
             request.run
           end
         end
@@ -23,7 +23,7 @@ describe Typhoeus::Request::Before do
         context "when false" do
           it "doesn't call super" do
             Typhoeus.before { false }
-            Typhoeus::Expectation.should_receive(:response_for).never
+            expect(Typhoeus::Expectation).to receive(:response_for).never
             request.run
           end
 
@@ -36,7 +36,7 @@ describe Typhoeus::Request::Before do
         context "when a response" do
           it "doesn't call super" do
             Typhoeus.before { Typhoeus::Response.new }
-            Typhoeus::Expectation.should_receive(:response_for).never
+            expect(Typhoeus::Expectation).to receive(:response_for).never
             request.run
           end
 
@@ -52,12 +52,12 @@ describe Typhoeus::Request::Before do
           before { 3.times { Typhoeus.before { |r| String.new(r.base_url) } } }
 
           it "calls super" do
-            Typhoeus::Expectation.should_receive(:response_for)
+            expect(Typhoeus::Expectation).to receive(:response_for)
             request.run
           end
 
           it "executes all" do
-            String.should_receive(:new).exactly(3).times.and_return("")
+            expect(String).to receive(:new).exactly(3).times.and_return("")
             request.run
           end
         end
@@ -70,12 +70,12 @@ describe Typhoeus::Request::Before do
           end
 
           it "doesn't call super" do
-            Typhoeus::Expectation.should_receive(:response_for).never
+            expect(Typhoeus::Expectation).to receive(:response_for).never
             request.run
           end
 
           it "executes only two" do
-            String.should_receive(:new).exactly(2).times.and_return("")
+            expect(String).to receive(:new).exactly(2).times.and_return("")
             request.run
           end
         end
@@ -84,7 +84,7 @@ describe Typhoeus::Request::Before do
 
     context "when no before" do
       it "calls super" do
-        Typhoeus::Expectation.should_receive(:response_for)
+        expect(Typhoeus::Expectation).to receive(:response_for)
         request.run
       end
     end

--- a/spec/typhoeus/request/cacheable_spec.rb
+++ b/spec/typhoeus/request/cacheable_spec.rb
@@ -27,7 +27,7 @@ describe Typhoeus::Request::Cacheable do
         before { cache.memory[request] = response }
 
         it "finishes request" do
-          request.should_receive(:finish).with(response)
+          expect(request).to receive(:finish).with(response)
           request.run
         end
 
@@ -51,7 +51,7 @@ describe Typhoeus::Request::Cacheable do
         before { cache.memory[request] = response }
 
         it "finishes request" do
-          request.should_receive(:finish).with(response)
+          expect(request).to receive(:finish).with(response)
           request.run
         end
       end

--- a/spec/typhoeus/request/callbacks_spec.rb
+++ b/spec/typhoeus/request/callbacks_spec.rb
@@ -18,7 +18,7 @@ describe Typhoeus::Request::Callbacks do
       context "when block given" do
         it "stores" do
           request.method(callback).call { p 1 }
-          expect(request.instance_variable_get("@#{callback}")).to have(1).items
+          expect(request.instance_variable_get("@#{callback}").size).to eq(1)
         end
       end
 
@@ -26,7 +26,7 @@ describe Typhoeus::Request::Callbacks do
         it "stores" do
           request.method(callback).call { p 1 }
           request.method(callback).call { p 2 }
-          expect(request.instance_variable_get("@#{callback}")).to have(2).items
+          expect(request.instance_variable_get("@#{callback}").size).to eq(2)
         end
       end
     end

--- a/spec/typhoeus/request/operations_spec.rb
+++ b/spec/typhoeus/request/operations_spec.rb
@@ -7,19 +7,19 @@ describe Typhoeus::Request::Operations do
 
   describe "#run" do
     let(:easy) { Ethon::Easy.new }
-    before { Typhoeus::Pool.should_receive(:get).and_return(easy) }
+    before { expect(Typhoeus::Pool).to receive(:get).and_return(easy) }
 
     it "grabs an easy" do
       request.run
     end
 
     it "generates settings" do
-      easy.should_receive(:http_request)
+      expect(easy).to receive(:http_request)
       request.run
     end
 
     it "performs" do
-      easy.should_receive(:perform)
+      expect(easy).to receive(:perform)
       request.run
     end
 
@@ -29,7 +29,7 @@ describe Typhoeus::Request::Operations do
     end
 
     it "releases easy" do
-      Typhoeus::Pool.should_receive(:release)
+      expect(Typhoeus::Pool).to receive(:release)
       request.run
     end
 
@@ -66,7 +66,7 @@ describe Typhoeus::Request::Operations do
 
     it "calls on_complete" do
       callback = double(:call)
-      callback.should_receive(:call)
+      expect(callback).to receive(:call)
       request.instance_variable_set(:@on_complete, [callback])
       request.run
     end
@@ -90,7 +90,7 @@ describe Typhoeus::Request::Operations do
     end
 
     it "executes callbacks" do
-      request.should_receive(:execute_callbacks)
+      expect(request).to receive(:execute_callbacks)
       request.finish(response)
     end
 

--- a/spec/typhoeus/request/stubbable_spec.rb
+++ b/spec/typhoeus/request/stubbable_spec.rb
@@ -14,7 +14,7 @@ describe Typhoeus::Request::Stubbable do
 
     context "when expectation found" do
       it "finishes request" do
-        request.should_receive(:finish)
+        expect(request).to receive(:finish)
         request.run
       end
 

--- a/spec/typhoeus/request_spec.rb
+++ b/spec/typhoeus/request_spec.rb
@@ -22,8 +22,8 @@ describe Typhoeus::Request do
 
     it "pushes an easy back into the pool" do
       easy = double.as_null_object
-      Typhoeus::Pool.stub(:get).and_return(easy)
-      Typhoeus::Pool.should_receive(:release).with(easy)
+      allow(Typhoeus::Pool).to receive(:get).and_return(easy)
+      expect(Typhoeus::Pool).to receive(:release).with(easy)
       request.url
     end
   end

--- a/spec/typhoeus/response/header_spec.rb
+++ b/spec/typhoeus/response/header_spec.rb
@@ -63,11 +63,11 @@ describe Typhoeus::Response::Header do
       end
 
       it "sets Set-Cookie" do
-        expect(header['set-cookie']).to have(3).items
+        expect(header['set-cookie'].size).to eq(3)
       end
 
       it "provides case insensitive access" do
-        expect(header['Set-CooKie']).to have(3).items
+        expect(header['Set-CooKie'].size).to eq(3)
       end
 
       [

--- a/spec/typhoeus/response/informations_spec.rb
+++ b/spec/typhoeus/response/informations_spec.rb
@@ -249,7 +249,7 @@ describe Typhoeus::Response::Informations do
       let(:options) { {:response_headers => "Server: A\r\n\r\nServer: B"} }
 
       it "returns response from all but last headers" do
-        expect(response.redirections).to have(1).item
+        expect(response.redirections.size).to eq(1)
       end
     end
   end

--- a/spec/typhoeus_spec.rb
+++ b/spec/typhoeus_spec.rb
@@ -43,7 +43,7 @@ describe Typhoeus do
 
       it "adds expectation" do
         Typhoeus.stub(:get, "")
-        expect(Typhoeus::Expectation.all).to have(1).item
+        expect(Typhoeus::Expectation.all.size).to eq(1)
       end
     end
 
@@ -59,7 +59,7 @@ describe Typhoeus do
 
       it "doesn't add expectation" do
         Typhoeus.stub(base_url)
-        expect(Typhoeus::Expectation.all).to have(1).item
+        expect(Typhoeus::Expectation.all.size).to eq(1)
       end
     end
   end
@@ -67,7 +67,7 @@ describe Typhoeus do
   describe ".before" do
     it "adds callback" do
       Typhoeus.before { true }
-      expect(Typhoeus.before).to have(1).item
+      expect(Typhoeus.before.size).to eq(1)
     end
   end
 


### PR DESCRIPTION
This conversion is done by Transpec 1.13.1 with the following command:
    transpec
- 69 conversions
  from: obj.should_receive(:message)
    to: expect(obj).to receive(:message)
- 12 conversions
  from: expect(collection).to have(n).items
    to: expect(collection.size).to eq(n)
- 2 conversions
  from: stub('something')
    to: double('something')
- 1 conversion
  from: obj.stub(:message)
    to: allow(obj).to receive(:message)
