### PR TITLE
Include more information in request string representation

### DIFF
--- a/lib/typhoeus/request.rb
+++ b/lib/typhoeus/request.rb
@@ -177,6 +177,10 @@ module Typhoeus
       Ethon::Easy::Form.new(nil, options[:body]).to_s
     end
 
+    def to_s
+      "#{self.class}(url: #{url}, options: #{original_options})"
+    end
+
     private
 
     # Checks if two hashes are equal or not, discarding

--- a/spec/typhoeus/request_spec.rb
+++ b/spec/typhoeus/request_spec.rb
@@ -190,4 +190,10 @@ describe Typhoeus::Request do
       expect(request.encoded_body).to eq("a=1")
     end
   end
+
+  describe "#to_s" do
+    it 'includes the url' do
+      expect(request.to_s).to include(base_url)
+    end
+  end
 end


### PR DESCRIPTION
## The Problem

Typhoeus does not override the default implementation for `to_s` on the `Typhoeus::Request` object.

## The Motivation

The default string presentation of `Typhoeus::Request` objects is generally unhelpful:

```ruby
request = Typhoeus::Request.new('http://localhost')
request.to_s
=> "#<Typhoeus::Request:0x007fdb91c58a18>"
```

One may want to log the request, but the only way to do so presently is to log each "piece" of the request individually. A contrived example:

```ruby
Logger.info("Request: url=#{request.url} options=#{request.options}")
```

It would be pretty cool if one could get helpful information by logging the request itself:

```ruby
Logger.info("Request: #{request}")
```

1. Simpler logging.
2. Possibly more robust (assuming a good string representation)

## The Solution

I didn't feel qualified to make decisions about how to best represent a `Typhoeus::Request` as a string, so I went with the simplest solution of delegating the call to Object#inspect.

Let me know what you think! I'm happy to adjust the implementation, rebase, etc. as needed.