### PR TITLE
Update the first Hydra example for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,25 +165,25 @@ request.run
 
 ### Making Parallel Requests
 
-Generally, you should be running requests through hydra. Here is how that looks
+Generally, you should be running requests through hydra. Here is how that looks:
 
 ```ruby
 hydra = Typhoeus::Hydra.hydra
 
-first_request = Typhoeus::Request.new("www.example.com/posts/1.json")
+first_request = Typhoeus::Request.new("http://example.com/posts/1")
 first_request.on_complete do |response|
-  third_request = Typhoeus::Request.new("www.example.com/posts/3.json")
+  # third_url = code_to_parse response.body
+  third_request = Typhoeus::Request.new(third_url)
   hydra.queue third_request
 end
-second_request = Typhoeus::Request.new("www.example.com/posts/2.json")
+second_request = Typhoeus::Request.new("http://localhost:3000/users/1.json")
 
 hydra.queue first_request
 hydra.queue second_request
-# this is a blocking call that returns once all requests are complete
-hydra.run
+hydra.run # this is a blocking call that returns once all requests are complete
 ```
 
-The execution of that code goes something like this. The first and second requests are built and queued. When hydra is run the first and second requests run in parallel. When the first request completes, the third request is then built and queued up. The moment it is queued Hydra starts executing it.  Meanwhile the second request would continue to run (or it could have completed before the first). Once the third request is done, `hydra.run` returns.
+The execution of that code goes something like this. The first and second requests are built and queued. When hydra is run the first and second requests run in parallel. When the first request completes, the third request is then built and queued, in this example based on the result of the first request. The moment it is queued Hydra starts executing it.  Meanwhile the second request would continue to run (or it could have completed before the first). Once the third request is done, `hydra.run` returns.
 
 How to get an array of response bodies back after executing a queue:
 
@@ -206,10 +206,10 @@ responses = requests.map { |request|
 hydra = Typhoeus::Hydra.new
 10.times.map { 
   request = Typhoeus::Request.new("www.example.com", followlocation: true)
-  hydra.queue(request) 
   request.on_complete do |response|
     #do_something_with response
   end
+  hydra.queue(request) 
 }
 hydra.run
 ```


### PR DESCRIPTION
 Revised the first parallel request example code (based on a previous version) to clarify that the third request is run in the context of the first request, and so is dependant on the result of the first request before it can be run, explaining the use of the callback.

Also reversed the order of the callback and queue in the third example, as the current code, if used in a callback to add a request to an already running queue, could result in a theoretical (if unlikely) race condition.
