### PR TITLE
Reverse the order of queue and on_complete in the third Hydra example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,13 +204,13 @@ responses = requests.map { |request|
 
 ```ruby
 hydra = Typhoeus::Hydra.new
-10.times.map { 
+10.times do 
   request = Typhoeus::Request.new("www.example.com", followlocation: true)
-  hydra.queue(request) 
   request.on_complete do |response|
     #do_something_with response
   end
-}
+  hydra.queue(request)
+end
 hydra.run
 ```
 


### PR DESCRIPTION
Revise the third Hydra example to reverse the order of the queue and callback definition. While not a problem with the code in its current form, I believe that if these two lines were reused in a more complex example they could result in an (albeit unlikely) race condition where the request could complete before the callback is defined.

Consider this example - an amalgamation of the first example and the third in its current form (i.e. third request queued before its callback is defined):

``` ruby
hydra = Typhoeus::Hydra.hydra

first_request = Typhoeus::Request.new("www.example.com/posts/1.json")
first_request.on_complete do |response|
  third_request = Typhoeus::Request.new("www.example.com/posts/3.json")
  hydra.queue third_request
  third_request.on_complete do |response|
    # do_something_with response
  end
end
second_request = Typhoeus::Request.new("www.example.com/posts/2.json")

hydra.queue first_request
hydra.queue second_request
# this is a blocking call that returns once all requests are complete
hydra.run
```

Because when the third request is queued hydra is already running, I'm assuming a race could occur. As I submitted this third example, and as the order of queue and callback was opposite to other examples, I thought it best to correct it.
