### PR TITLE
Remove outdated documentation in Callbacks

### DIFF
--- a/lib/typhoeus/request/callbacks.rb
+++ b/lib/typhoeus/request/callbacks.rb
@@ -2,7 +2,6 @@ module Typhoeus
   class Request
 
     # This module contains the logic for the response callbacks.
-    # The on_complete callback is the only one at the moment.
     #
     # You can set multiple callbacks, which are then executed
     # in the same order.


### PR DESCRIPTION
I was looking for an excuse to contribute to a gem I use quite often so there you go :)