### PR TITLE
Forking may cause libcurl sockets to be shared with child processes, causing HTTP requests to be interleaved

### DIFF
--- a/lib/typhoeus/pool.rb
+++ b/lib/typhoeus/pool.rb
@@ -9,6 +9,7 @@ module Typhoeus
   # @api private
   module Pool
     @mutex = Mutex.new
+    @pid = Process.pid
 
     # Releases easy into the pool. The easy handle is
     # reset before it gets back in.
@@ -27,7 +28,17 @@ module Typhoeus
     #
     # @return [ Ethon::Easy ] The easy.
     def self.get
-      @mutex.synchronize { easies.pop } || Ethon::Easy.new
+      @mutex.synchronize do
+        if @pid == Process.pid
+          easies.pop
+        else
+          # Process has forked. Clear all easies to avoid sockets being
+          # shared between processes.
+          @pid = Process.pid
+          easies.clear
+          nil
+        end
+      end || Ethon::Easy.new
     end
 
     # Clear the pool

--- a/spec/typhoeus/pool_spec.rb
+++ b/spec/typhoeus/pool_spec.rb
@@ -59,6 +59,18 @@ describe Typhoeus::Pool do
         end
       end
     end
+
+    context "when forked" do
+      before do
+        allow(Process).to receive(:pid).and_return(1)
+        Typhoeus::Pool.send(:easies) << easy
+        allow(Process).to receive(:pid).and_return(2)
+      end
+
+      it "creates" do
+        expect(Typhoeus::Pool.get).to_not eq(easy)
+      end
+    end
   end
 
   describe "#with" do

--- a/spec/typhoeus/pool_spec.rb
+++ b/spec/typhoeus/pool_spec.rb
@@ -67,6 +67,11 @@ describe Typhoeus::Pool do
         allow(Process).to receive(:pid).and_return(2)
       end
 
+      after do
+        allow(Process).to receive(:pid).and_call_original
+        Typhoeus::Pool.instance_variable_set(:@pid, Process.pid)
+      end
+
       it "creates" do
         expect(Typhoeus::Pool.get).to_not eq(easy)
       end


### PR DESCRIPTION
After a (Ruby) process is forked, the child process shares any open file descriptors with the parent. This also applies to sockets.

This leads to problems in the following scenario:

- perform HTTP request in parent
- fork parent
- perform HTTP request in parent and child simultaneously

The last two requests have a risk of being interleaved because they will be transmitted over the same socket. It happens because instances of `Ethon::Easy` are reused automatically by `Typhoeus::Pool`. This means Typhoeus is not fork-safe by default.

I think a workaround is simple, we can simply call `Typhoeus::Pool.clear` after forking.

However, in our particular use case we're trying to abstract away the HTTP adapter by using Faraday.

Additionally, I'm inclined to think making `fork()` safe to use is the responsibility of the HTTP library.

Therefore I'm proposing to add a check for the current process id in either `Typhoeus::Pool` or `Ethon::Easy`. If the current pid does not match the pid of the process used when it was constructed, then a new instance should be used instead.

This is a similar approach as used in this memcache client: https://github.com/mperham/dalli/blob/533792caf97e909332e72263afcca0f2ffec8577/lib/dalli/server.rb#L204

What do you think of this approach? If you agree with the solution, I'd be happy to prepare a PR.