### PR TITLE
respect URI scheme in Faraday::Adapter::Typhoeus

### DIFF
--- a/lib/typhoeus/adapters/faraday.rb
+++ b/lib/typhoeus/adapters/faraday.rb
@@ -128,7 +128,7 @@ module Faraday # :nodoc:
         proxy = env[:request][:proxy]
         return unless proxy
 
-        req.options[:proxy] = "#{proxy[:uri].host}:#{proxy[:uri].port}"
+        req.options[:proxy] = "#{proxy[:uri].scheme}://#{proxy[:uri].host}:#{proxy[:uri].port}"
 
         if proxy[:user] && proxy[:password]
           req.options[:proxyuserpwd] = "#{proxy[:user]}:#{proxy[:password]}"

--- a/spec/typhoeus/adapters/faraday_spec.rb
+++ b/spec/typhoeus/adapters/faraday_spec.rb
@@ -159,16 +159,16 @@ describe Faraday::Adapter::Typhoeus do
     before { adapter.method(:configure_proxy).call(request, env) }
 
     context "when proxy" do
-      let(:env) { { :request => { :proxy => { :uri => double(:host => "localhost", :port => "3001") } } } }
+      let(:env) { { :request => { :proxy => { :uri => double(:scheme => 'http', :host => "localhost", :port => "3001") } } } }
 
       it "sets proxy" do
-        expect(request.options[:proxy]).to eq("localhost:3001")
+        expect(request.options[:proxy]).to eq("http://localhost:3001")
       end
 
       context "when username and password" do
         let(:env) do
           { :request => { :proxy => {
-            :uri => double(:host => :a, :port => :b),
+            :uri => double(:scheme => 'http', :host => :a, :port => :b),
             :user => "a",
             :password => "b"
           } } }


### PR DESCRIPTION
To be able to use socks5:// as proxy proto:
````
require 'faraday'
require 'typhoeus/adapters/faraday'
puts /Congratulations. This browser is configured to use Tor./.match(
Faraday::Connection.new('https://check.torproject.org') do |b| 
  b.proxy 'socks5://127.0.0.1:9050';
  b.adapter :typhoeus;
end.get.body
) || 'nope'
```