### PR TITLE
Fix Regexp expectation on request with nil base_url

### DIFF
--- a/lib/typhoeus/expectation.rb
+++ b/lib/typhoeus/expectation.rb
@@ -205,7 +205,7 @@ module Typhoeus
       when String
         base_url == request_url
       when Regexp
-        !!request_url.match(base_url)
+        base_url === request_url
       when nil
         true
       else

--- a/spec/typhoeus/expectation_spec.rb
+++ b/spec/typhoeus/expectation_spec.rb
@@ -201,6 +201,14 @@ describe Typhoeus::Expectation do
         it "returns false" do
           expect(url_match).to be_falsey
         end
+
+        context "with nil request_url" do
+          let(:request_url) { nil }
+
+          it "returns false" do
+            expect(url_match).to be_falsey
+          end
+        end
       end
     end
 


### PR DESCRIPTION
At the moment, Typhoeus throws an exception when stubbing using Regexp and trying to run a Request with `nil` as base url.

Usually a Request with `nil` as url simply returns an error Response

```ruby
Typhoeus::Request.new(nil).run
# => #<Typhoeus::Response:0x007f2c35d3d728 ...>
```

Creating a Regexp stub and running a Request with `nil`:

```ruby
Typhoeus.stub(/.*/).and_return(Typhoeus::Response.new(code: 200, body: "Typhoeus rocks"))
Typhoeus::Request.new(nil).run
# NoMethodError: undefined method `match' for nil:NilClass
```