### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ Typhoeus.delete("www.example.com/posts/1")
 Typhoeus.options("www.example.com")
 ```
 #### Sending params in the body with PUT
-When using POST the content-type is set automatically to 'application/x-www-form-urlencoded'. Thats not the case for any other method like PUT, PATCH, HEAD and so on,  irrespective of whether you are using body or not. To get the same result as POST, i.e. a hash in the body coming through as params in the receiver, you need to set the content-type as shown below:
+When using POST the content-type is set automatically to 'application/x-www-form-urlencoded'. That's not the case for any other method like PUT, PATCH, HEAD and so on,  irrespective of whether you are using body or not. To get the same result as POST, i.e. a hash in the body coming through as params in the receiver, you need to set the content-type as shown below:
 ```ruby
 Typhoeus.put("www.example.com/posts/1",
         headers: {'Content-Type'=> "application/x-www-form-urlencoded"},
-        body: {name:"Test", text: "Example text"}
+        body: {title:"test post updated title", content: "this is my updated content"}
     )
 ```
 


### PR DESCRIPTION
just fix punctuation of 'Thats' => 'That's' and adjusted the example body params to be similar to previous example in README for POST for clarity.