### PR TITLE
Added getter for redirect_time value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Master
+
+[Full Changelog](http://github.com/typhoeus/typhoeus/compare/v0.7.1...master)
+
+* Added getter for `redirect_time` value.
+  ([Adrien Jarthon](https://github.com/jarthod))
+
 ## 0.7.1
 
 [Full Changelog](http://github.com/typhoeus/typhoeus/compare/v0.7.0...v0.7.1)

--- a/lib/typhoeus/response/informations.rb
+++ b/lib/typhoeus/response/informations.rb
@@ -160,6 +160,19 @@ module Typhoeus
       end
       alias :name_lookup_time :namelookup_time
 
+      # Return the time, in seconds, it took for all redirection steps
+      # include name lookup, connect, pretransfer and transfer before the
+      # final transaction was started. time_redirect shows the complete
+      # execution time for multiple redirections.
+      #
+      # @example Get redirect_time.
+      #   response.redirect_time
+      #
+      # @return [ Float ] The redirect_time.
+      def redirect_time
+        options[:redirect_time]
+      end
+
       # Return the last used effective url.
       #
       # @example Get effective_url.

--- a/spec/typhoeus/response/informations_spec.rb
+++ b/spec/typhoeus/response/informations_spec.rb
@@ -152,6 +152,14 @@ describe Typhoeus::Response::Informations do
     end
   end
 
+  describe "#redirect_time" do
+    let(:options) { { :redirect_time =>  1 } }
+
+    it "returns redirect_time from options" do
+      expect(response.redirect_time).to eq(1)
+    end
+  end
+
   describe "#effective_url" do
     let(:options) { { :effective_url => "http://www.example.com" } }
 

--- a/typhoeus.gemspec
+++ b/typhoeus.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.license = 'MIT'
 
-  s.add_dependency('ethon', [">= 0.7.1"])
+  s.add_dependency('ethon', [">= 0.7.2"])
 
   s.files        = `git ls-files`.split("\n")
   s.test_files   = `git ls-files -- spec/*`.split("\n")


### PR DESCRIPTION
This PR depends on https://github.com/typhoeus/ethon/pull/101, which adds the `redirect_time` to `ethon` and simply adds the getter to `typhoeus`. It raises the required ethon version.

BTW I, of course, tested both projects together and I get the correct `redirect_time` :+1: 