### PR TITLE
add support to specify Faraday adapter options

### DIFF
--- a/lib/typhoeus/adapters/faraday.rb
+++ b/lib/typhoeus/adapters/faraday.rb
@@ -48,6 +48,22 @@ module Faraday # :nodoc:
 
       dependency 'typhoeus'
 
+      # Allow configuring some adapter specific parameters
+      #
+      # @example Configure SSL client key password
+      #   Faraday.new(faraday_options) do |faraday|
+      #     faraday.adapter :typhoeus, ssl: { client_cert_passwd: 'yolo' }
+      #   end
+      #
+      # @param [ App ] app The Faraday app.
+      # @param [ Hash ] adapter_options The adapter specific options.
+      #
+      # @return [ void ]
+      def initialize(app = nil, adapter_options = {})
+        @adapter_options = adapter_options
+        super(app)
+      end
+
       # Hook into Faraday and perform the request with Typhoeus.
       #
       # @param [ Hash ] env The environment.
@@ -108,7 +124,8 @@ module Faraday # :nodoc:
       end
 
       def configure_ssl(req, env)
-        ssl = env[:ssl]
+        ssl_adapter_options = @adapter_options[:ssl] || {}
+        ssl = env[:ssl].to_hash.merge(ssl_adapter_options)
 
         verify_p = (ssl && ssl.fetch(:verify, true))
 

--- a/spec/typhoeus/adapters/faraday_spec.rb
+++ b/spec/typhoeus/adapters/faraday_spec.rb
@@ -271,6 +271,15 @@ describe Faraday::Adapter::Typhoeus do
         expect(request.options[:ssl_verifypeer]).to be_truthy
       end
     end
+
+    context "when options specified in @adapter_options" do
+      let(:env) { {} }
+      let(:adapter) { described_class.new(nil, ssl: { client_cert_passwd: 'my secret passphrase' }) }
+
+      it "sets keypasswd to the value of client_cert_passwd" do
+        expect(request.options[:keypasswd]).to eq("my secret passphrase")
+      end
+    end
   end
 
   describe "#parallel?" do


### PR DESCRIPTION
This adds support for specific adapter options in a similar way the Faraday Excon adapter already does.

I needed `client_cert_passwd`, so I just added support for SSL config parameters.
