### PR TITLE
Adds support for a default user agent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,15 @@ Typhoeus::Config.verbose = true
 Just remember that libcurl prints it’s debug output to the console (to
 STDERR), so you’ll need to run your scripts from the console to see it.
 
+### Default User Agent Header
+
+In many cases, all HTTP requests made by an application require the same User-Agent header set. Instead of supplying it on a per-request basis by supplying a custom header, it is possible to override it for all requests using:
+
+
+```ruby
+Typhoeus::Config.user_agent = "custom user agent"
+```
+
 ### Running the specs
 
 Running the specs should be as easy as:
@@ -548,4 +557,3 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/typhoeus/typhoeus/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
-

--- a/lib/typhoeus/config.rb
+++ b/lib/typhoeus/config.rb
@@ -51,5 +51,12 @@ module Typhoeus
     # @see Typhoeus::Hydra::Cacheable
     # @see Typhoeus::Request::Cacheable
     attr_accessor :cache
+
+    # Defines whether to use a default user agent.
+    #
+    # @return [ String ]
+    #
+    # @see Typhoeus::Request#set_defaults
+    attr_accessor :user_agent
   end
 end

--- a/lib/typhoeus/request.rb
+++ b/lib/typhoeus/request.rb
@@ -209,10 +209,12 @@ module Typhoeus
 
     # Sets default header and verbose when turned on.
     def set_defaults
+      default_user_agent = Config.user_agent || Typhoeus::USER_AGENT
+
       if @options[:headers]
-        @options[:headers] = {'User-Agent' => Typhoeus::USER_AGENT}.merge(options[:headers])
+        @options[:headers] = {'User-Agent' => default_user_agent}.merge(options[:headers])
       else
-        @options[:headers] = {'User-Agent' => Typhoeus::USER_AGENT}
+        @options[:headers] = {'User-Agent' => default_user_agent}
       end
       @options[:verbose] = Typhoeus::Config.verbose if @options[:verbose].nil? && !Typhoeus::Config.verbose.nil?
       @options[:maxredirs] ||= 50

--- a/spec/typhoeus/config_spec.rb
+++ b/spec/typhoeus/config_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Typhoeus::Config do
   let(:config) { Typhoeus::Config }
 
-  [:block_connection, :memoize, :verbose, :cache].each do |name|
+  [:block_connection, :memoize, :verbose, :cache, :user_agent].each do |name|
     it "responds to #{name}" do
       expect(config).to respond_to(name)
     end

--- a/spec/typhoeus/request_spec.rb
+++ b/spec/typhoeus/request_spec.rb
@@ -65,6 +65,27 @@ describe Typhoeus::Request do
       end
     end
 
+    context "when Config.user_agent set" do
+      before { Typhoeus.configure { |config| config.user_agent = "Default" } }
+      after { Typhoeus.configure { |config| config.user_agent = nil } }
+
+      context "with headers" do
+        let(:options) { {:headers => { "User-Agent" => "Fubar" } } }
+
+        it "uses the request options' user agent" do
+          expect(request.options[:headers]["User-Agent"]).to eq("Fubar")
+        end
+      end
+
+      context "without headers" do
+        let(:options) { {:headers => {} } }
+
+        it "uses the global options' user agent" do
+          expect(request.options[:headers]["User-Agent"]).to eq("Default")
+        end
+      end
+    end
+
     context "when Config.verbose set" do
       before { Typhoeus.configure { |config| config.verbose = true} }
       after { Typhoeus.configure { |config| config.verbose = false} }


### PR DESCRIPTION
Some rationale: I added this functionality since I have several projects which always seem to override the user agent for each request. We require the User-Agent header for each request to be overridden since our internal firewall only whitelists certain User-Agents; the Typhoeus user agent will not likely be added any time soon. Adding this once to the application initialization code seems cleaner than overriding it for a request each time.

If it's unwanted, please close the PR. Tests were added for the new functionality, which pass:

```
408 examples, 0 failures, 1 pending
```