### PR TITLE
Faraday adapter: parallel request timeouts should give feedback

### DIFF
--- a/lib/typhoeus/adapters/faraday.rb
+++ b/lib/typhoeus/adapters/faraday.rb
@@ -86,9 +86,8 @@ module Faraday # :nodoc:
 
         req.on_complete do |resp|
           if resp.timed_out?
-            if parallel?(env)
-              # TODO: error callback in async mode
-            else
+            env[:typhoeus_timed_out] = true
+            unless parallel?(env)
               raise Faraday::Error::TimeoutError, "request timed out"
             end
           end


### PR DESCRIPTION
I'm just sticking a boolean `:typhoeus_timed_out` onto the `env` hash.  Then middleware or clients can see that and respond appropriately to timeouts.

I'm not sure if this is the best or most appropriate feedback to give, but it's better than nothing!  What do you think?  Is there a better way?