### PR TITLE
Faraday adapter can provide sub-second timeouts without warnings

### DIFF
--- a/lib/typhoeus/adapters/faraday.rb
+++ b/lib/typhoeus/adapters/faraday.rb
@@ -137,8 +137,8 @@ module Faraday # :nodoc:
 
       def configure_timeout(req, env)
         env_req = env[:request]
-        req.options[:timeout_ms] = (env_req[:timeout] * 1000)             if env_req[:timeout]
-        req.options[:connecttimeout_ms] = (env_req[:open_timeout] * 1000) if env_req[:open_timeout]
+        req.options[:timeout_ms] = (env_req[:timeout] * 1000).to_i             if env_req[:timeout]
+        req.options[:connecttimeout_ms] = (env_req[:open_timeout] * 1000).to_i if env_req[:open_timeout]
       end
 
       def configure_socket(req, env)


### PR DESCRIPTION
Faraday timeouts are expressed in seconds, and I was getting error messages on the console when I tried to assign subsecond (float) timeouts.