### PR TITLE
EasyFactory: Reduced object allocations and method calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 [Full Changelog](http://github.com/typhoeus/typhoeus/compare/v0.7.3...master)
 
+* `EasyFactory`: Reduced object allocations and method calls during deprecated option handling.
+  ([Tasos Laskos](https://github.com/zapotek)
+
 ## 0.7.3
 
 [Full Changelog](http://github.com/typhoeus/typhoeus/compare/v0.7.2...v0.7.3)

--- a/lib/typhoeus/easy_factory.rb
+++ b/lib/typhoeus/easy_factory.rb
@@ -8,6 +8,31 @@ module Typhoeus
   # @api private
   class EasyFactory
 
+    RENAMED_OPTIONS =  {
+          :auth_method => :httpauth,
+          :connect_timeout => :connecttimeout,
+          :encoding => :accept_encoding,
+          :follow_location => :followlocation,
+          :max_redirects => :maxredirs,
+          :proxy_type => :proxytype,
+          :ssl_cacert => :cainfo,
+          :ssl_capath => :capath,
+          :ssl_cert => :sslcert,
+          :ssl_cert_type => :sslcerttype,
+          :ssl_key => :sslkey,
+          :ssl_key_password => :keypasswd,
+          :ssl_key_type => :sslkeytype,
+          :ssl_version => :sslversion,
+      }
+
+    CHANGED_OPTIONS =  {
+          :disable_ssl_host_verification => :ssl_verifyhost,
+          :disable_ssl_peer_verification => :ssl_verifypeer,
+          :proxy_auth_method => :proxyauth,
+      }
+
+    REMOVED_OPTIONS =  Set.new([:cache_key_basis, :cache_timeout, :user_agent])
+
     # Returns the request provided.
     #
     # @return [ Typhoeus::Request ]
@@ -70,7 +95,7 @@ module Typhoeus
       request.options.each do |k,v|
         s = k.to_sym
         next if [:method, :cache_ttl].include?(s)
-        if new_option = renamed_options[k.to_sym]
+        if new_option = RENAMED_OPTIONS[k.to_sym]
           warn("Deprecated option #{k}. Please use #{new_option} instead.")
           sanitized[new_option] = v
         # sanitize timeouts
@@ -134,41 +159,10 @@ module Typhoeus
       end
     end
 
-    def renamed_options
-      {
-        :auth_method => :httpauth,
-        :connect_timeout => :connecttimeout,
-        :encoding => :accept_encoding,
-        :follow_location => :followlocation,
-        :max_redirects => :maxredirs,
-        :proxy_type => :proxytype,
-        :ssl_cacert => :cainfo,
-        :ssl_capath => :capath,
-        :ssl_cert => :sslcert,
-        :ssl_cert_type => :sslcerttype,
-        :ssl_key => :sslkey,
-        :ssl_key_password => :keypasswd,
-        :ssl_key_type => :sslkeytype,
-        :ssl_version => :sslversion,
-      }
-    end
-
-    def changed_options
-      {
-        :disable_ssl_host_verification => :ssl_verifyhost,
-        :disable_ssl_peer_verification => :ssl_verifypeer,
-        :proxy_auth_method => :proxyauth,
-      }
-    end
-
-    def removed_options
-      [:cache_key_basis, :cache_timeout, :user_agent]
-    end
-
     def provide_help(option)
-      if new_option = changed_options[option.to_sym]
+      if new_option = CHANGED_OPTIONS[option.to_sym]
         "\nPlease try #{new_option} instead of #{option}." if new_option
-      elsif removed_options.include?(option.to_sym)
+      elsif REMOVED_OPTIONS.include?(option.to_sym)
         "\nThe option #{option} was removed."
       end
     end


### PR DESCRIPTION
Methods that just create static objects cost us the object allocation + method call, better use constants instead.