### PR TITLE
Eliminate warnings

### DIFF
--- a/lib/typhoeus/expectation.rb
+++ b/lib/typhoeus/expectation.rb
@@ -137,7 +137,7 @@ module Typhoeus
     # @return [ void ]
     def and_return(response=nil, &block)
       new_response = (response.nil? ? block : response)
-      responses.push *new_response
+      responses.push(*new_response)
     end
 
     # Checks whether this expectation matches

--- a/lib/typhoeus/request/streamable.rb
+++ b/lib/typhoeus/request/streamable.rb
@@ -27,7 +27,7 @@ module Typhoeus
       #
       # @return [ Boolean ] True if any on_body blocks have been set.
       def streaming?
-        @on_body && @on_body.any?
+        defined?(@on_body) && @on_body.any?
       end
     end
   end

--- a/lib/typhoeus/response/cacheable.rb
+++ b/lib/typhoeus/response/cacheable.rb
@@ -7,7 +7,7 @@ module Typhoeus
       attr_writer :cached
 
       def cached?
-        !!@cached
+        defined?(@cached) ? !!@cached : false
       end
     end
   end


### PR DESCRIPTION
typhoeus/lib/typhoeus/request/streamable.rb:30: warning: instance variable @on_body not initialized
typhoeus/lib/typhoeus/expectation.rb:140: warning: `*' interpreted as argument prefix
typhoeus/lib/typhoeus/response/cacheable.rb:10: warning: instance variable @cached not initialized
