### PR TITLE
Convert max_concurrency to an integer

### DIFF
--- a/lib/typhoeus/hydra.rb
+++ b/lib/typhoeus/hydra.rb
@@ -88,7 +88,7 @@ module Typhoeus
     #   Ethon::Multi#initialize
     def initialize(options = {})
       @options = options
-      @max_concurrency = @options.fetch(:max_concurrency, 200)
+      @max_concurrency = Integer(@options.fetch(:max_concurrency, 200))
       @multi = Ethon::Multi.new(options.reject{|k,_| k==:max_concurrency})
     end
   end

--- a/spec/typhoeus/hydra/queueable_spec.rb
+++ b/spec/typhoeus/hydra/queueable_spec.rb
@@ -83,6 +83,16 @@ describe Typhoeus::Hydra::Queueable do
           hydra.dequeue_many
         end
       end
+
+      context "when max_concurrency is a string" do
+        let(:options) { {:max_concurrency => "2"} }
+        it "adds requests from queue to multi" do
+          expect(hydra).to receive(:add).with(first)
+          expect(hydra).to receive(:add).with(second)
+          expect(hydra).to_not receive(:add).with(third)
+          hydra.dequeue_many
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Hydra would accept a string value for max_concurrency, but it would
result in all requests running in parallel (equivalent to setting
max_concurrency to infinity).

See debugging session:

<img width="812" alt="screen shot 2015-12-23 at 10 59 22 pm" src="https://cloud.githubusercontent.com/assets/1191305/11989748/63ad14e6-a9d1-11e5-88b9-ee84911d1e9b.png">

It's also possible to set `max_concurrency` through the attr_accessor, and this will not help with that. I figured I'd get an initial PR in first to get others' thoughts before getting too far into it.
