### PR TITLE
Make tests passing for Rubies 2.1 – 2.3 and < 1.9.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: ruby
 script: "bundle exec rake"
 sudo: false
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 2.1.8
+  - 2.2.4
+  - 2.3.0
   - ruby-head
   - jruby-head
   - jruby-18mode

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,11 @@
 source "https://rubygems.org"
 gemspec
 
-gem "rake"
+if Gem.ruby_version < Gem::Version.new("1.9.3")
+  gem "rake", "< 11"
+else
+  gem "rake"
+end
 
 group :development, :test do
   gem "rspec", "~> 3.0"

--- a/spec/typhoeus/hydra/runnable_spec.rb
+++ b/spec/typhoeus/hydra/runnable_spec.rb
@@ -106,8 +106,9 @@ describe Typhoeus::Hydra::Runnable do
       end
       let(:second) { Typhoeus::Request.new("localhost:3001/second") }
       let(:requests) { [first] }
+      let(:on_complete_counter){ double :mark => :twain }
 
-      before { Typhoeus.on_complete { |r| String.new(r.code) } }
+      before { Typhoeus.on_complete { |r| on_complete_counter.mark } }
       after { Typhoeus.on_complete.clear; Typhoeus.before.clear }
 
       context "when real request" do
@@ -115,7 +116,7 @@ describe Typhoeus::Hydra::Runnable do
           let(:options) { {} }
 
           it "calls on_complete callback once for every response" do
-            expect(String).to receive(:new).exactly(2).times
+            expect(on_complete_counter).to receive(:mark).exactly(2).times
             hydra.run
           end
         end
@@ -126,7 +127,7 @@ describe Typhoeus::Hydra::Runnable do
           before { Typhoeus.before{ |request|  request.finish(Typhoeus::Response.new) } }
 
           it "simulates real multi run and adds and finishes both requests" do
-            expect(String).to receive(:new).exactly(2).times
+            expect(on_complete_counter).to receive(:mark).exactly(2).times
             hydra.run
           end
         end


### PR DESCRIPTION
1. Typhoeus is now tested against a wider selection of Rubies
2. Tests do not fail for older Rubies
3. Few tests have been fixed and they pass on Ruby 2.3
4. Language has been set in Travis configuration
5. #510 fixed.