### PR TITLE
Flush cookies to disk and clear cookies in memory

### DIFF
--- a/lib/typhoeus/pool.rb
+++ b/lib/typhoeus/pool.rb
@@ -17,7 +17,9 @@ module Typhoeus
     # @example Release easy.
     #   Typhoeus::Pool.release(easy)
     def self.release(easy)
+      easy.cookielist = "flush" # dump all known cookies to 'cookiejar'
       easy.reset
+      easy.cookielist = "all" # remove all cookies from memory for this handle
       @mutex.synchronize { easies << easy }
     end
 

--- a/lib/typhoeus/pool.rb
+++ b/lib/typhoeus/pool.rb
@@ -18,8 +18,8 @@ module Typhoeus
     #   Typhoeus::Pool.release(easy)
     def self.release(easy)
       easy.cookielist = "flush" # dump all known cookies to 'cookiejar'
-      easy.reset
       easy.cookielist = "all" # remove all cookies from memory for this handle
+      easy.reset
       @mutex.synchronize { easies << easy }
     end
 

--- a/spec/support/server.rb
+++ b/spec/support/server.rb
@@ -23,6 +23,14 @@ TESTSERVER = Sinatra.new do
     [200, { 'Set-Cookie' => %w[ foo bar ], 'Content-Type' => 'text/plain' }, ['']]
   end
 
+  get '/cookies-test' do
+    [200, { 'Set-Cookie' => %w(foo=bar bar=foo), 'Content-Type' => 'text/plain' }, ['']]
+  end
+
+  get '/cookies-test2' do
+    [200, { 'Set-Cookie' => %w(foo2=bar bar2=foo), 'Content-Type' => 'text/plain' }, ['']]
+  end
+
   get '/fail/:number' do
     if fail_count >= params[:number].to_i
       "ok"

--- a/spec/typhoeus/pool_spec.rb
+++ b/spec/typhoeus/pool_spec.rb
@@ -16,6 +16,13 @@ describe Typhoeus::Pool do
       Typhoeus::Pool.release(easy)
     end
 
+    it "flush cookies to disk" do
+      expect(easy).to receive(:cookielist=).with('flush')
+      expect(easy).to receive(:reset)
+      expect(easy).to receive(:cookielist=).with('all')
+      Typhoeus::Pool.release(easy)
+    end
+
     it "puts easy back into pool" do
       Typhoeus::Pool.release(easy)
       expect(Typhoeus::Pool.send(:easies)).to include(easy)

--- a/spec/typhoeus/pool_spec.rb
+++ b/spec/typhoeus/pool_spec.rb
@@ -23,6 +23,38 @@ describe Typhoeus::Pool do
       Typhoeus::Pool.release(easy)
     end
 
+    it "writes cookies to disk" do
+      tempfile1 = Tempfile.new('cookies')
+      tempfile2 = Tempfile.new('cookies')
+
+      easy.cookiejar = tempfile1.path
+      easy.url = "localhost:3001/cookies-test"
+      easy.perform
+
+      Typhoeus::Pool.release(easy)
+
+      expect(File.zero?(tempfile1.path)).to be(false)
+      expect(File.read(tempfile1.path)).to match(/\s+foo\s+bar$/)
+      expect(File.read(tempfile1.path)).to match(/\s+bar\s+foo$/)
+
+      # do it again - and check if tempfile1 wasn't change
+      easy.cookiejar = tempfile2.path
+      easy.url = "localhost:3001/cookies-test2"
+      easy.perform
+
+      Typhoeus::Pool.release(easy)
+
+      # tempfile 1
+      expect(File.zero?(tempfile1.path)).to be(false)
+      expect(File.read(tempfile1.path)).to match(/\s+foo\s+bar$/)
+      expect(File.read(tempfile1.path)).to match(/\s+bar\s+foo$/)
+
+      # tempfile2
+      expect(File.zero?(tempfile2.path)).to be(false)
+      expect(File.read(tempfile2.path)).to match(/\s+foo2\s+bar$/)
+      expect(File.read(tempfile2.path)).to match(/\s+bar2\s+foo$/)
+    end
+
     it "puts easy back into pool" do
       Typhoeus::Pool.release(easy)
       expect(Typhoeus::Pool.send(:easies)).to include(easy)


### PR DESCRIPTION
Hi,
first of all, sorry for my bad english.

Just a few hours ago I ran into that issue when I was writing tests for my app. I use post request to login to some webpage. When I tested "Login failed" I was not able to simulate this behavior because easy handle in pool helds cookies in memory from previous (successful) login. And keep sending old cookies to server.

Don't know if this behavior is a future or a bug. In this pull request I propose solution for this issue.

Also I'm not sure if this fix should be in Typhoeus or in Ethon.