### PR TITLE
Set proxyauth to "any" when Faraday request includes proxy credentials.

### DIFF
--- a/lib/typhoeus/adapters/faraday.rb
+++ b/lib/typhoeus/adapters/faraday.rb
@@ -135,6 +135,7 @@ module Faraday # :nodoc:
         req.options[:proxy] = "#{proxy[:uri].scheme}://#{proxy[:uri].host}:#{proxy[:uri].port}"
 
         if proxy[:user] && proxy[:password]
+          req.options[:proxyauth] = :any
           req.options[:proxyuserpwd] = "#{proxy[:user]}:#{proxy[:password]}"
         end
       end


### PR DESCRIPTION
#463 would provide a framework for a more general solution to this, I can work on fixing up that PR instead if you think this is too inflexible.