### PR TITLE
Response::Header#parse: Stip lines

### DIFF
--- a/lib/typhoeus/response/header.rb
+++ b/lib/typhoeus/response/header.rb
@@ -33,6 +33,7 @@ module Typhoeus
           end
         when String
           raw.lines.each do |header|
+            header.strip!
             next if header.empty? || header.start_with?( 'HTTP/1.' )
             process_line(header)
           end

--- a/spec/typhoeus/response/header_spec.rb
+++ b/spec/typhoeus/response/header_spec.rb
@@ -92,6 +92,19 @@ describe Typhoeus::Response::Header do
           expect(header[name.downcase]).to eq(value)
         end
       end
+
+      context 'includes line with only whitespace' do
+          let(:raw) do
+              'HTTP/1.1 200 OK
+               Date: Fri, 29 Jun 2012 10:09:23 GMT
+
+'
+        end
+
+        it 'ignores it' do
+          expect(header).to eq({ 'Date' => 'Fri, 29 Jun 2012 10:09:23 GMT' })
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes error when a line with only whitespace is available.