### PR TITLE
Expose return_message in Faraday env

### DIFF
--- a/lib/typhoeus/adapters/faraday.rb
+++ b/lib/typhoeus/adapters/faraday.rb
@@ -92,6 +92,7 @@ module Faraday # :nodoc:
             end
           elsif resp.response_code == 0
             env[:typhoeus_connection_failed] = true
+            env[:typhoeus_return_message] = resp.return_message
             unless parallel?(env)
               raise Faraday::Error::ConnectionFailed, resp.return_message
             end


### PR DESCRIPTION
Answering #524: Include the return_message in the Faraday environment when the parallel manager is in active.