### PR TITLE
allow global proxy setting using Typhoeus::Config.proxy = "…"

### DIFF
--- a/lib/typhoeus/config.rb
+++ b/lib/typhoeus/config.rb
@@ -58,5 +58,12 @@ module Typhoeus
     #
     # @see Typhoeus::Request#set_defaults
     attr_accessor :user_agent
+
+    # Defines wether to use a proxy server for every request.
+    #
+    # @return [ String ]
+    #
+    # @see Typhoeus::Request#set_defaults
+    attr_accessor :proxy
   end
 end

--- a/lib/typhoeus/request.rb
+++ b/lib/typhoeus/request.rb
@@ -214,6 +214,7 @@ module Typhoeus
       options[:headers] = {'User-Agent' => default_user_agent}.merge(options[:headers] || {})
       options[:verbose] = Typhoeus::Config.verbose if options[:verbose].nil? && !Typhoeus::Config.verbose.nil?
       options[:maxredirs] ||= 50
+      options[:proxy] = Typhoeus::Config.proxy unless options.has_key?(:proxy) || Typhoeus::Config.proxy.nil?
     end
   end
 end

--- a/spec/typhoeus/config_spec.rb
+++ b/spec/typhoeus/config_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Typhoeus::Config do
   let(:config) { Typhoeus::Config }
 
-  [:block_connection, :memoize, :verbose, :cache, :user_agent].each do |name|
+  [:block_connection, :memoize, :verbose, :cache, :user_agent, :proxy].each do |name|
     it "responds to #{name}" do
       expect(config).to respond_to(name)
     end

--- a/spec/typhoeus/request_spec.rb
+++ b/spec/typhoeus/request_spec.rb
@@ -110,6 +110,23 @@ describe Typhoeus::Request do
         end
       end
     end
+
+    context "when Config.proxy set" do
+      before { Typhoeus.configure { |config| config.proxy = "http://proxy.internal" } }
+      after { Typhoeus.configure { |config| config.proxy = nil } }
+
+      it "respects" do
+        expect(request.options[:proxy]).to eq("http://proxy.internal")
+      end
+
+      context "when option proxy set" do
+        let(:options) { {:proxy => nil} }
+
+        it "does not override" do
+          expect(request.options[:proxy]).to be_nil
+        end
+      end
+    end
   end
 
   describe "#eql?" do


### PR DESCRIPTION
Hi,

I wanted to submit this suggestion, as for our application it seemed very helpful to configure a proxy server that should be used for every request.

The application I am working for is running behind an egress firewall with a proxy server guarding connections to the outside world.

For explicit configuration I want to introduce:

```ruby
Typhoeus.configure { |config| config.proxy = "http://proxy.internal" }
```

My suggestion in `Typhoeus::Request#set_defaults` allows to _unset_ the proxy configuration too:

```ruby
# request going through http://proxy.internal as configured above
Typhoeus.get("http://google.de")

# request directly
Typhoeus.get("http://google.de", proxy: nil)
```

Please let me know what you think and whether you want to merge this PR.

Best regards, Lukas