### PR TITLE
[FIX] Add Expect flag to all requests as default, should solve performance issues 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,11 @@
 source "https://rubygems.org"
 gemspec
 
-if Gem.ruby_version < Gem::Version.new("1.9.3")
+if Gem.ruby_version < Gem::Version.new("2.0.0")
   gem "rake", "< 11"
+  gem "json", "< 2"  
 else
+  gem "json"
   gem "rake"
 end
 
@@ -11,7 +13,6 @@ group :development, :test do
   gem "rspec", "~> 3.0"
 
   gem "sinatra", "~> 1.3"
-  gem "json"
   gem "faraday", ">= 0.9"
 
   if RUBY_PLATFORM == "java"

--- a/lib/typhoeus/request.rb
+++ b/lib/typhoeus/request.rb
@@ -212,6 +212,7 @@ module Typhoeus
       default_user_agent = Config.user_agent || Typhoeus::USER_AGENT
 
       options[:headers] = {'User-Agent' => default_user_agent}.merge(options[:headers] || {})
+      options[:headers]['Expect'] ||= ''
       options[:verbose] = Typhoeus::Config.verbose if options[:verbose].nil? && !Typhoeus::Config.verbose.nil?
       options[:maxredirs] ||= 50
       options[:proxy] = Typhoeus::Config.proxy unless options.has_key?(:proxy) || Typhoeus::Config.proxy.nil?

--- a/spec/typhoeus/request_spec.rb
+++ b/spec/typhoeus/request_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Typhoeus::Request do
   let(:base_url) { "localhost:3001" }
-  let(:options) { {:verbose => true, :headers => { 'User-Agent' => "Fubar" }, :maxredirs => 50} }
+  let(:options) { {:verbose => true, :headers => { 'User-Agent' => "Fubar", 'Expect' => "" }, :maxredirs => 50} }
   let(:request) { Typhoeus::Request.new(base_url, options) }
 
   describe ".url" do
@@ -167,7 +167,7 @@ describe Typhoeus::Request do
 
         context "when different order" do
           let(:other_options) {
-            {:headers => { 'User-Agent' => "Fubar" }, :verbose => true }
+            {:headers => { 'User-Agent' => "Fubar", 'Expect' => ""}, :verbose => true }
           }
           let(:other) { Typhoeus::Request.new(base_url, other_options)}
 
@@ -183,7 +183,7 @@ describe Typhoeus::Request do
     context "when request.eql?(other)" do
       context "when different order" do
         let(:other_options) {
-          {:headers => { 'User-Agent' => "Fubar" }, :verbose => true }
+          {:headers => { 'User-Agent' => "Fubar", 'Expect' => "" }, :verbose => true }
         }
         let(:other) { Typhoeus::Request.new(base_url, other_options)}
 
@@ -228,4 +228,5 @@ describe Typhoeus::Request do
       expect(request.encoded_body).to eq("a=1")
     end
   end
+
 end


### PR DESCRIPTION
Add Expect flag to all requests as default, should solve performance issues of servers that does not return status code 100 by default

Based on analysis done by @linrock

As part of:
https://github.com/typhoeus/ethon/issues/115

I was not so comfortable with adding this specifically to PUT, as it seems the typhoeus
 infra is not so much geared for such setup. But if I missed anything, happy to fix.