### PR TITLE
Add support for multi-line headers

### DIFF
--- a/lib/typhoeus/response/header.rb
+++ b/lib/typhoeus/response/header.rb
@@ -32,7 +32,7 @@ module Typhoeus
             process_pair(k, v)
           end
         when String
-          raw.lines.each do |header|
+          raw.split(/\r?\n(?!\s)/).each do |header|
             header.strip!
             next if header.empty? || header.start_with?( 'HTTP/1.' )
             process_line(header)
@@ -47,7 +47,7 @@ module Typhoeus
       # @return [ void ]
       def process_line(header)
         key, value = header.split(':', 2)
-        process_pair(key.strip, value.strip)
+        process_pair(key.strip, value.strip.gsub(/\r?\n\s*/, ' '))
       end
 
       # Sets key value pair for self and @sanitized.

--- a/spec/typhoeus/response/header_spec.rb
+++ b/spec/typhoeus/response/header_spec.rb
@@ -55,7 +55,7 @@ describe Typhoeus::Response::Header do
         Server: gws
         X-XSS-Protection: 1; mode=block
         X-Frame-Options: SAMEORIGIN
-        Transfer-Encoding: chunked'
+        Transfer-Encoding: chunked'.gsub(/^\s{8}/, '')
       end
 
       it "sets raw" do
@@ -93,12 +93,29 @@ describe Typhoeus::Response::Header do
         end
       end
 
-      context 'includes line with only whitespace' do
-          let(:raw) do
-              'HTTP/1.1 200 OK
-               Date: Fri, 29 Jun 2012 10:09:23 GMT
+      context 'includes a multi-line header' do
+        let(:raw) do
+          'HTTP/1.1 200 OK
+          Date: Fri, 29 Jun 2012 10:09:23 GMT
+          Content-Security-Policy: default-src "self";
+            img-src * data: "self";
+            upgrade-insecure-requests;'.gsub(/^\s{10}/, '')
+        end
 
-'
+        it "joins header parts" do
+          expect(header).to eq({
+            'Date' => 'Fri, 29 Jun 2012 10:09:23 GMT',
+            'Content-Security-Policy' => 'default-src "self"; img-src * data: "self"; upgrade-insecure-requests;'
+          })
+        end
+      end
+
+      context 'includes line with only whitespace' do
+        let(:raw) do
+          'HTTP/1.1 200 OK
+          Date: Fri, 29 Jun 2012 10:09:23 GMT
+            
+          '.gsub(/^\s{10}/, '')
         end
 
         it 'ignores it' do


### PR DESCRIPTION
Hi, I noticed recently that Typhoeus was failing to parse multi-line headers, which although not very popular exists in the wild ^^

Here is an example of multi-line header which makes Typhoeus fail:
```
$ curl -I https://hashbang.ca
HTTP/1.1 200 OK
Server: nginx
Date: Fri, 16 Dec 2016 21:30:11 GMT
Content-Type: text/html; charset=UTF-8
Connection: keep-alive
Vary: Accept-Encoding
Link: <https://hashbang.ca/wp-json/>; rel="https://api.w.org/"
Expires: Fri, 16 Dec 2016 22:30:11 GMT
Cache-Control: max-age=3600
Strict-Transport-Security: max-age=31536000; includeSubDomains
Content-Security-Policy: default-src 'self';
        img-src     * data: 'self';
        style-src   https://platform.twitter.com https://fonts.googleapis.com https://secure.gravatar.com https://gist-assets.github.com https://assets-cdn.github.com 'unsafe-inline' 'self';
        font-src    https://fonts.googleapis.com https://themes.googleusercontent.com https://fonts.gstatic.com data: 'unsafe-inline' 'self';
        script-src  https://syndication.twitter.com https://platform.twitter.com https://api.flattr.com https://secure.gravatar.com https://asciinema.org https://*.github.com 'unsafe-inline' 'unsafe-eval' 'self';
        child-src   https://syndication.twitter.com https://platform.twitter.com https://speakerdeck.com https://www.youtube.com https://api.flattr.com https://*.soundcloud.com https://asciinema.org 'self';
        frame-ancestors https://hashbang.ca https://*.hashbang.ca https://mikedoherty.ca;
        report-uri  https://csp.hashbang.ca;
        referrer no-referrer;
        upgrade-insecure-requests;
```

And here the error raised: `undefined method 'strip' for nil:NilClass`

This is because Typhoeus simply split headers by newlines, in this fix I attempt to respect the spec better by splitting the headers on newlines *with no space or tab on next line*, as this means the same header value continues. I then strip newlines and extra spaces in the parsed value.

I added spec for this and had to hack a bit the raw header strings in the specs as they were actually containing leading spaces everywhere. I would have preferred using the [squiggly heredoc syntax](https://infinum.co/the-capsized-eight/multiline-strings-ruby-2-3-0-the-squiggly-heredoc) but this means the spec would only run on ruby `2.3.1+` so I supposed you would prefer a more compatible version.

I'm using my patched version for [updown.io](https://updown.io) and it's working perfectly on 6000+ different websites.

References:
https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html
http://stackoverflow.com/questions/31237198/is-it-possible-to-include-multiple-crlfs-in-a-http-header-field
http://stackoverflow.com/questions/8627263/multi-line-http-headers-confusion