### PR TITLE
support array values in mock response_headers

### DIFF
--- a/lib/typhoeus/response/informations.rb
+++ b/lib/typhoeus/response/informations.rb
@@ -47,7 +47,7 @@ module Typhoeus
       def response_headers
         return options[:response_headers] if options[:response_headers]
         if mock? && h = options[:headers]
-            h.map{ |k,v| [k, v.respond_to?(:join) ? v.join : v] }.
+            h.map{ |k,v| [k, v.respond_to?(:join) ? v.join(',') : v] }.
               map{ |e| "#{e.first}: #{e.last}" }.
               join("\r\n")
         end

--- a/spec/typhoeus/response/informations_spec.rb
+++ b/spec/typhoeus/response/informations_spec.rb
@@ -74,6 +74,17 @@ describe Typhoeus::Response::Informations do
             expect(response.response_headers).to include("\r\n")
           end
         end
+
+        context "when multiple values for a header" do
+          let(:options) { { :mock => true, :headers => {"Length" => 1, "Content-Type" => "text/plain", "set-cookie" => ["cookieone=one","cookietwo=two"] } } }
+
+          it "constructs response_headers" do
+            expect(response.response_headers).to include("Length: 1")
+            expect(response.response_headers).to include("Content-Type: text/plain")
+            expect(response.response_headers).to include("set-cookie: cookieone=one,cookietwo=two")
+            expect(response.response_headers).to include("\r\n")
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
fixes a bug in which array value headers are parsed incorrectly when using `mock: true`