### PR TITLE
Add failure? method to status class

### DIFF
--- a/lib/typhoeus/response/status.rb
+++ b/lib/typhoeus/response/status.rb
@@ -46,7 +46,18 @@ module Typhoeus
       #
       # @return [ Boolean ] Return true if successful, false else.
       def success?
-        (mock || return_code == :ok) && response_code && response_code >= 200 && response_code < 300
+        (mock || return_code == :ok) && response_code && has_good_response_code?
+      end
+
+      # Return wether the response is a failure.
+      #
+      # @example Return if the response was failed.
+      #  response.failure?
+      #
+      # @return [ Boolean ] Return true if failure, false else.
+
+      def failure?
+        (mock || return_code == :internal_server_error) && response_code && has_bad_response_code?
       end
 
       # Return wether the response is modified.
@@ -80,6 +91,16 @@ module Typhoeus
             response_headers.to_s.split("\r\n").first
           end
         end
+      end
+
+      # :nodoc:
+      def has_good_response_code?
+        response_code >= 200 && response_code < 300
+      end
+
+      # :nodoc:
+      def has_bad_response_code?
+        !has_good_response_code?
       end
     end
   end

--- a/spec/typhoeus/response/status_spec.rb
+++ b/spec/typhoeus/response/status_spec.rb
@@ -128,6 +128,60 @@ describe Typhoeus::Response::Status do
     end
   end
 
+  describe "#failure?" do
+    context "when response code between 300-526 and 100-300" do
+      let(:options) { {:return_code => return_code, :response_code => 300} }
+
+      context "when mock" do
+        before { response.mock = true }
+
+        context "when return_code :internal_server_error" do
+          let(:return_code) { :internal_server_error }
+
+          it "returns true" do
+            expect(response.failure?).to be_truthy
+          end
+        end
+
+        context "when return_code nil" do
+          let(:return_code) { nil }
+
+          it "returns true" do
+            expect(response.failure?).to be_truthy
+          end
+        end
+      end
+
+      context "when no mock" do
+        before { response.mock = nil }
+
+        context "when return_code :internal_server_error" do
+          let(:return_code) { :internal_server_error }
+
+          it "returns true" do
+            expect(response.failure?).to be_truthy
+          end
+        end
+
+        context "when return_code nil" do
+          let(:return_code) { nil }
+
+          it "returns false" do
+            expect(response.failure?).to be_falsey
+          end
+        end
+      end
+    end
+
+    context "when response code is not 300-526" do
+      let(:options) { {:return_code => :ok, :response_code => 200} }
+
+      it "returns false" do
+        expect(response.failure?).to be_falsey
+      end
+    end
+  end
+
   describe "#modified?" do
     context "when response code 304" do
       let(:options) { {:return_code => :ok, :response_code => 304} }


### PR DESCRIPTION
We have `success?` method that returns a boolean value. I think we need opposite of it.

Purpose of that clients(devs) who are using the gem are enforced to write:

```ruby
if !response.success? && my_own_condition
  ### logic
end
```

By adding this `failure?` method they will be able to write more readable and well designed code.

```ruby
if response.failure? && my_own_condition
end
```

Thanks! :beers: 