### PR TITLE
Better support for broken headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - 2.1.8
   - 2.2.4
   - 2.3.0
+  - 2.4.1
   - ruby-head
   - jruby-head
   - jruby-18mode

--- a/lib/typhoeus/response/header.rb
+++ b/lib/typhoeus/response/header.rb
@@ -47,7 +47,7 @@ module Typhoeus
       # @return [ void ]
       def process_line(header)
         key, value = header.split(':', 2)
-        process_pair(key.strip, value.strip.gsub(/\r?\n\s*/, ' '))
+        process_pair(key.strip, (value ? value.strip.gsub(/\r?\n\s*/, ' ') : nil))
       end
 
       # Sets key value pair for self and @sanitized.

--- a/lib/typhoeus/response/header.rb
+++ b/lib/typhoeus/response/header.rb
@@ -47,7 +47,7 @@ module Typhoeus
       # @return [ void ]
       def process_line(header)
         key, value = header.split(':', 2)
-        process_pair(key.strip, (value ? value.strip.gsub(/\r?\n\s*/, ' ') : nil))
+        process_pair(key.strip, (value ? value.strip.gsub(/\r?\n\s*/, ' ') : ''))
       end
 
       # Sets key value pair for self and @sanitized.

--- a/spec/typhoeus/response/header_spec.rb
+++ b/spec/typhoeus/response/header_spec.rb
@@ -122,6 +122,23 @@ describe Typhoeus::Response::Header do
           expect(header).to eq({ 'Date' => 'Fri, 29 Jun 2012 10:09:23 GMT' })
         end
       end
+
+      context 'with broken headers' do
+        let(:raw) do
+          'HTTP/1.1 200 OK
+          Date:
+          Content-Type
+          '.gsub(/^\s{10}/, '')
+        end
+
+        it 'returns empty string if no value' do
+          expect(header).to include({ 'Date' => '' })
+        end
+
+        it 'returns nil if no column' do
+          expect(header).to include({ 'Content-Type' => nil })
+        end
+      end
     end
   end
 end

--- a/spec/typhoeus/response/header_spec.rb
+++ b/spec/typhoeus/response/header_spec.rb
@@ -131,12 +131,8 @@ describe Typhoeus::Response::Header do
           '.gsub(/^\s{10}/, '')
         end
 
-        it 'returns empty string if no value' do
-          expect(header).to include({ 'Date' => '' })
-        end
-
-        it 'returns nil if no column' do
-          expect(header).to include({ 'Content-Type' => nil })
+        it 'returns empty string for invalid headers' do
+          expect(header).to include({ 'Date' => '', 'Content-Type' => '' })
         end
       end
     end


### PR DESCRIPTION
Hello,

I just found another issue with typhoeus's header parsing with a simple case of invalid syntax:
```
HTTP/1.1 200 OK
Content-Type
```

Which currently raises:
```
NoMethodError: undefined method `strip' for nil:NilClass
  from typhoeus/response/header.rb:50:in `process_line'
  from typhoeus/response/header.rb:38:in `block in parse'
  from typhoeus/response/header.rb:35:in `each'
  from typhoeus/response/header.rb:35:in `parse'
  from typhoeus/response/header.rb:20:in `initialize'
  from typhoeus/response/informations.rb:226:in `new'
  from typhoeus/response/informations.rb:226:in `headers'
```

Because of the `value.strip.gsub(/\r?\n\s*/, ' ')` when value is `nil`.

Here is a simple patch which prevents `nil` values from breaking header parsing, along with a spec checking this case (and the empty header case too).

I also added ruby `2.4.1` to the travis CI matrix, let me know if you want me to remove this from this PR.