### PR TITLE
Ensure that responses are Marshal-able

### DIFF
--- a/lib/typhoeus/response/header.rb
+++ b/lib/typhoeus/response/header.rb
@@ -6,7 +6,7 @@ module Typhoeus
     # Values can be strings (normal case) or arrays of strings (for duplicates headers)
     #
     # @api private
-    class Header < Hash
+    class Header < DelegateClass(Hash)
 
       # Create a new header.
       #
@@ -15,6 +15,7 @@ module Typhoeus
       #
       # @param [ String ] raw The raw header.
       def initialize(raw)
+        super({})
         @raw = raw
         @sanitized = {}
         parse

--- a/lib/typhoeus/response/header.rb
+++ b/lib/typhoeus/response/header.rb
@@ -18,7 +18,10 @@ module Typhoeus
         @raw = raw
         @sanitized = {}
         parse
-        set_default_proc_on(self, lambda { |h, k| @sanitized[k.to_s.downcase] })
+      end
+
+      def [](key)
+        fetch(key) { @sanitized[key.to_s.downcase] }
       end
 
       # Parses the raw header.

--- a/spec/typhoeus/response/header_spec.rb
+++ b/spec/typhoeus/response/header_spec.rb
@@ -132,7 +132,7 @@ describe Typhoeus::Response::Header do
         end
 
         it 'returns empty string for invalid headers' do
-          expect(header).to include({ 'Date' => '', 'Content-Type' => '' })
+          expect(header.to_hash).to include({ 'Date' => '', 'Content-Type' => '' })
         end
       end
     end

--- a/spec/typhoeus/response/header_spec.rb
+++ b/spec/typhoeus/response/header_spec.rb
@@ -137,4 +137,11 @@ describe Typhoeus::Response::Header do
       end
     end
   end
+
+  it "can be Marshal'd" do
+    header = Typhoeus::Response::Header.new("Foo: Bar")
+    expect {
+      Marshal.dump(header)
+    }.not_to raise_error
+  end
 end

--- a/spec/typhoeus/response/informations_spec.rb
+++ b/spec/typhoeus/response/informations_spec.rb
@@ -243,7 +243,7 @@ describe Typhoeus::Response::Informations do
         end
 
         it "returns headers" do
-          expect(response.headers).to include("Length" => "1")
+          expect(response.headers.to_hash).to include("Length" => "1")
         end
       end
     end


### PR DESCRIPTION
### What

Currently, instances of `Typhoeus::Header` are not compatible with `Marshal.dump`. This is because it uses a hash with a default block, which cannot be marshaled:

```ruby
h = Hash.new { "a" }
Marshal.dump(h)
# TypeError: can't dump hash with default proc
#   from (irb):2:in `dump'
#   from (irb):2
#   from /Users/pablobm/.rbenv/versions/2.4.0/bin/irb:11:in `<main>'
```

I have come across a corner case where this doesn't work well with Ruby on Rails's cache stores. I'll elaborate.

Normally `Typhoeus::Response` can be marshaled. It stores the headers raw, as a string, and all is good. However, when `#headers` is invoked, this string is parsed into a `Typhoeus::Header` instance and then memoized as `@headers`. It's now that there's a problem: `Marshal.dump` serializes the response by serializing each of its properties, and here's one that cannot be handled.

The specific use case that triggered this for me was using the VCR gem with Typhoeus and Rails, all while using Rails caching. I actually solved it with just disabling the cache, as I didn't need it. However, two reasons occur to me why it may be a good idea to fix this anyway:

  1. It's confusing if it happens to you! It took me a while to figure out what was going on, and what the simplest solution was (disabling the cache).
  2. You may want to run integration test with the cache enabled.

### How

To solve this, I avoid the default proc and instead replicate its behaviour by overriding `#[]` and using `fetch`. That's the first of the two commits below.

And that should be enough... but I went a bit further. Inheriting from core classes (such as `Hash`) is normally discouraged as it can have unexpected consequences. Instead I use `DelegateClass`.

There's a caveat to this new change though. RSpec's implementation of `include` is very particular in that it explicitly tests `is_a?(Hash)` in order to perform the hash inclusion matcher. Therefore, we need to explicitly convert to `Hash` (ironically using the *implicit* conversion `#to_hash`) when using it. This is something I'd like to take to the RSpec people, but that's a different story. Anyway, that's the second commit.

### Notes

The build breaks because of https://github.com/typhoeus/typhoeus/issues/574