### PR TITLE
Fix Faraday 0.12.2 incompatibility

### DIFF
--- a/lib/typhoeus/response/informations.rb
+++ b/lib/typhoeus/response/informations.rb
@@ -47,7 +47,9 @@ module Typhoeus
       def response_headers
         return options[:response_headers] if options[:response_headers]
         if mock? && h = options[:headers]
-            status_line = "HTTP/1.1 #{return_code} Mock Reason Phrase"
+            status_code = return_code || "200"
+            reason_phrase = status_code == "200" ? "OK" : "Mock Reason Phrase"
+            status_line = "HTTP/1.1 #{status_code} #{reason_phrase}"
             actual_headers = h.map{ |k,v| [k, v.respond_to?(:join) ? v.join(',') : v] }.
               map{ |e| "#{e.first}: #{e.last}" }
 

--- a/lib/typhoeus/response/informations.rb
+++ b/lib/typhoeus/response/informations.rb
@@ -47,9 +47,11 @@ module Typhoeus
       def response_headers
         return options[:response_headers] if options[:response_headers]
         if mock? && h = options[:headers]
-            h.map{ |k,v| [k, v.respond_to?(:join) ? v.join(',') : v] }.
-              map{ |e| "#{e.first}: #{e.last}" }.
-              join("\r\n")
+            status_line = "HTTP/1.1 #{return_code} Mock Reason Phrase"
+            actual_headers = h.map{ |k,v| [k, v.respond_to?(:join) ? v.join(',') : v] }.
+              map{ |e| "#{e.first}: #{e.last}" }
+
+            [status_line, *actual_headers].join("\r\n")
         end
       end
 


### PR DESCRIPTION
As mentioned at https://github.com/typhoeus/typhoeus/issues/574, Faraday (since v0.12.2) expects the status line to be present when receiving a string of headers to parse. This is currently breaking the build, as mock responses do not provide this status line.

This PR addresses the issue. For a status code, it uses the value provided by `options[:return_code]`, or `"200"` if not provided. For a status phrase, it uses `"OK"` when the code is `"200"` and an arbitrary (yet hopefully descriptive) sentence otherwise. An arbitrary sentence should be OK as RFC-2616 specifies that this is intended only for human users: https://tools.ietf.org/html/rfc2616#section-6.1.1