### PR TITLE
Add note to the Readme about :abort stream feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,19 @@ end
 request.run
 ```
 
+If you need to interrupt the stream halfway,
+you can return the `:abort` symbol from the `on_body` block, example:
+
+```ruby
+request.on_body do |chunk|
+  buffer << chunk
+  :abort if buffer.size > 1024 * 1024
+end
+```
+
+This will properly stop the stream internally and avoid any memory leak which
+may happen if you interrupt with something like a `return`, `throw` or `raise`.
+
 ### Making Parallel Requests
 
 Generally, you should be running requests through hydra. Here is how that looks:


### PR DESCRIPTION
I spent quite some time finding how to do this 4 years ago when the feature wasn't implemented and found some hackish way to do it with a `return` I then recently noticed that it caused memory leaks with certain curl options (gzip compression) and tried to find a better way but only found it in some tickets.
So I think this needs to be added to the readme, let me know what you think ;)