### PR TITLE
Add missing require for DelegateClass

### DIFF
--- a/lib/typhoeus/response/header.rb
+++ b/lib/typhoeus/response/header.rb
@@ -1,3 +1,5 @@
+require 'delegate'
+
 module Typhoeus
   class Response
 


### PR DESCRIPTION
To ensure DelegateClass has been loaded, header.rb needs to require 'delegate'.