### PR TITLE
Check Responses Return code

### DIFF
--- a/lib/typhoeus/adapters/faraday.rb
+++ b/lib/typhoeus/adapters/faraday.rb
@@ -99,7 +99,7 @@ module Faraday # :nodoc:
             unless parallel?(env)
               raise Faraday::Error::TimeoutError, "request timed out"
             end
-          elsif resp.response_code == 0
+          elsif (resp.response_code == 0 || resp.return_code != :ok)
             env[:typhoeus_connection_failed] = true
             env[:typhoeus_return_message] = resp.return_message
             unless parallel?(env)


### PR DESCRIPTION
If you don't check the response's return code then on :recv_error, you'll return impartial information to users without  clear information that there was an issue.

Found while investigating https://github.com/typhoeus/typhoeus/issues/537