### PR TITLE
Docs - Update Request::Actions rdoc

### DIFF
--- a/lib/typhoeus/request/actions.rb
+++ b/lib/typhoeus/request/actions.rb
@@ -15,7 +15,7 @@ module Typhoeus
       #
       # @option (see Typhoeus::Request#initialize)
       #
-      # @return (see Typhoeus::Request#initialize)
+      # @return (see Typhoeus::Response#initialize)
       #
       # @note (see Typhoeus::Request#initialize)
       def get(base_url, options = {})
@@ -31,7 +31,7 @@ module Typhoeus
       #
       # @option (see Typhoeus::Request#initialize)
       #
-      # @return (see Typhoeus::Request#initialize)
+      # @return (see Typhoeus::Response#initialize)
       #
       # @note (see Typhoeus::Request#initialize)
       def post(base_url, options = {})
@@ -50,7 +50,7 @@ module Typhoeus
       # @option options :body [ Hash ] Body hash which
       #   becomes a PUT request body.
       #
-      # @return (see Typhoeus::Request#initialize)
+      # @return (see Typhoeus::Response#initialize)
       #
       # @note (see Typhoeus::Request#initialize)
       def put(base_url, options = {})
@@ -66,7 +66,7 @@ module Typhoeus
       #
       # @option (see Typhoeus::Request#initialize)
       #
-      # @return (see Typhoeus::Request#initialize)
+      # @return (see Typhoeus::Response#initialize)
       #
       # @note (see Typhoeus::Request#initialize)
       def delete(base_url, options = {})
@@ -82,7 +82,7 @@ module Typhoeus
       #
       # @option (see Typhoeus::Request#initialize)
       #
-      # @return (see Typhoeus::Request#initialize)
+      # @return (see Typhoeus::Response#initialize)
       #
       # @note (see Typhoeus::Request#initialize)
       def head(base_url, options = {})
@@ -98,7 +98,7 @@ module Typhoeus
       #
       # @option (see Typhoeus::Request#initialize)
       #
-      # @return (see Typhoeus::Request#initialize)
+      # @return (see Typhoeus::Response#initialize)
       #
       # @note (see Typhoeus::Request#initialize)
       def patch(base_url, options = {})
@@ -114,7 +114,7 @@ module Typhoeus
       #
       # @option (see Typhoeus::Request#initialize)
       #
-      # @return (see Typhoeus::Request#initialize)
+      # @return (see Typhoeus::Response#initialize)
       #
       # @note (see Typhoeus::Request#initialize)
       def options(base_url, options = {})


### PR DESCRIPTION
Fix incorrect return value for http verb shortcuts.

[The return value of `Typhoeus::Request::Operations#run`](https://github.com/typhoeus/typhoeus/blob/fa7691d47a6af059174c9adcf582c40eac72e831/lib/typhoeus/request/operations.rb#L17) should be a `Response` not a `Request`.

--------

Noticed a typo in the docs going back... forever maybe 😁 ? This has bitten us a couple times so figured it might be tripping up others.

I'm not entirely sure how this would work, but if accepted could this be backported to old versions to update docs there as well? Is it worth doing?

Thanks for the fantastic library!