### PR TITLE
Add on_progress callback

### DIFF
--- a/lib/typhoeus/easy_factory.rb
+++ b/lib/typhoeus/easy_factory.rb
@@ -155,6 +155,11 @@ module Typhoeus
           request.execute_headers_callbacks(Response.new(Ethon::Easy::Mirror.from_easy(easy).options))
         end
       end
+      request.on_progress.each do |callback|
+        easy.on_progress do |dltotal, dlnow, ultotal, ulnow, easy|
+          callback.call(dltotal, dlnow, ultotal, ulnow, response)
+        end
+      end
       easy.on_complete do |easy|
         request.finish(Response.new(easy.mirror.options))
         Typhoeus::Pool.release(easy)

--- a/lib/typhoeus/request/callbacks.rb
+++ b/lib/typhoeus/request/callbacks.rb
@@ -89,6 +89,24 @@ module Typhoeus
           @on_headers << block if block_given?
           @on_headers
         end
+
+        # Set on_progress callback.
+        #
+        # @example Set on_progress.
+        #   request.on_progress do |dltotal, dlnow, ultotal, ulnow|
+        #     puts "dltotal (#{dltotal}), dlnow (#{dlnow}), ultotal (#{ultotal}), ulnow (#{ulnow})"
+        #   end
+        #
+        # @param [ Block ] block The block to execute.
+        #
+        # @yield [ Typhoeus::Response ]
+        #
+        # @return [ Array<Block> ] All on_progress blocks.
+        def on_progress(&block)
+          @on_progress ||= []
+          @on_progress << block if block_given?
+          @on_progress
+        end
       end
 
       # Execute the headers callbacks and yields response.
@@ -106,8 +124,8 @@ module Typhoeus
       end
 
       # Execute necessary callback and yields response. This
-      # include in every case on_complete, on_success if
-      # successful and on_failure if not.
+      # include in every case on_complete and on_progress, on_success
+      # if successful and on_failure if not.
       #
       # @example Execute callbacks.
       #   request.execute_callbacks
@@ -116,7 +134,7 @@ module Typhoeus
       #
       # @api private
       def execute_callbacks
-        callbacks = Typhoeus.on_complete + on_complete
+        callbacks = Typhoeus.on_complete + Typhoeus.on_progress + on_complete + on_progress
 
         if response && response.success?
           callbacks += Typhoeus.on_success + on_success

--- a/lib/typhoeus/request/marshal.rb
+++ b/lib/typhoeus/request/marshal.rb
@@ -5,9 +5,9 @@ module Typhoeus
     module Marshal
 
       # Return the important data needed to serialize this Request, except the
-      # `on_complete`, `on_success`, `on_failure`, and `hydra`, since they cannot be marshalled.
+      # request callbacks and `hydra`, since they cannot be marshalled.
       def marshal_dump
-        unmarshallable = %w(@on_complete @on_success @on_failure @on_headers @on_body @hydra)
+        unmarshallable = %w(@on_complete @on_success @on_failure @on_progress @on_headers @on_body @hydra)
         (instance_variables - unmarshallable - unmarshallable.map(&:to_sym)).map do |name|
           [name, instance_variable_get(name)]
         end

--- a/spec/typhoeus/easy_factory_spec.rb
+++ b/spec/typhoeus/easy_factory_spec.rb
@@ -104,6 +104,12 @@ describe Typhoeus::EasyFactory do
   end
 
   describe "#set_callback" do
+    it "sets easy.on_progress callback when an on_progress callback is provided" do
+      request.on_progress { 1 }
+      expect(easy_factory.easy).to receive(:on_progress)
+      easy_factory.send(:set_callback)
+    end
+
     it "sets easy.on_complete callback" do
       expect(easy_factory.easy).to receive(:on_complete)
       easy_factory.send(:set_callback)

--- a/spec/typhoeus/request/callbacks_spec.rb
+++ b/spec/typhoeus/request/callbacks_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Typhoeus::Request::Callbacks do
   let(:request) { Typhoeus::Request.new("fubar") }
 
-  [:on_complete, :on_success, :on_failure].each do |callback|
+  [:on_complete, :on_success, :on_failure, :on_progress].each do |callback|
     describe "##{callback}" do
       it "responds" do
         expect(request).to respond_to(callback)
@@ -33,7 +33,7 @@ describe Typhoeus::Request::Callbacks do
   end
 
   describe "#execute_callbacks" do
-    [:on_complete, :on_success, :on_failure].each do |callback|
+    [:on_complete, :on_success, :on_failure, :on_progress].each do |callback|
       context "when #{callback}" do
         context "when local callback" do
           before do

--- a/spec/typhoeus/request/marshal_spec.rb
+++ b/spec/typhoeus/request/marshal_spec.rb
@@ -5,7 +5,7 @@ describe Typhoeus::Request::Marshal do
   let(:request) { Typhoeus::Request.new(base_url) }
 
   describe "#marshal_dump" do
-    %w(on_complete on_success on_failure).each do |name|
+    %w(on_complete on_success on_failure on_progress).each do |name|
       context "when #{name} handler" do
         before { request.instance_variable_set("@#{name}", Proc.new{}) }
 


### PR DESCRIPTION
This closes out issue https://github.com/typhoeus/typhoeus/issues/554.

The `on_progress` callback was [added to ethon](https://github.com/typhoeus/ethon/pull/139) but as far as I can tell [BackOrder's change](https://github.com/typhoeus/typhoeus/commit/1ed499a0c3f8a8859e386ba1d084ac03b8af23e5) was never added to typhoeus.

This adds the `on_progress` callback and some tests.