### PR TITLE
Ability to set cache adapter on a per-request basis.

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,14 @@ Typhoeus::Config.cache = Typhoeus::Cache::Redis.new(redis)
 All three of these adapters take an optional keyword argument `default_ttl`, which sets a default
 TTL on cached responses (in seconds), for requests which do not have a cache TTL set.
 
+You may also selectively choose not to cache by setting `cache` to `false` on a request or to use
+a different adapter.
+
+```ruby
+cache = Cache.new
+Typhoeus.get("www.example.com", cache: cache)
+```
+
 ### Direct Stubbing
 
 Hydra allows you to stub out specific urls and patterns to avoid hitting

--- a/lib/typhoeus/easy_factory.rb
+++ b/lib/typhoeus/easy_factory.rb
@@ -35,7 +35,7 @@ module Typhoeus
 
     REMOVED_OPTIONS =  Set.new([:cache_key_basis, :cache_timeout, :user_agent])
 
-    SANITIZE_IGNORE  = Set.new([:method, :cache_ttl])
+    SANITIZE_IGNORE  = Set.new([:method, :cache_ttl, :cache])
     SANITIZE_TIMEOUT = Set.new([:timeout_ms, :connecttimeout_ms])
 
     # Returns the request provided.

--- a/lib/typhoeus/request/cacheable.rb
+++ b/lib/typhoeus/request/cacheable.rb
@@ -2,16 +2,16 @@ module Typhoeus
   class Request
     module Cacheable
       def response=(response)
-        Typhoeus::Config.cache.set(self, response) if cacheable? && !response.cached?
+        cache.set(self, response) if cacheable? && !response.cached?
         super
       end
 
       def cacheable?
-        Typhoeus::Config.cache
+        cache
       end
 
       def run
-        if cacheable? && response = Typhoeus::Config.cache.get(self)
+        if cacheable? && response = cache.get(self)
           response.cached = true
           finish(response)
         else
@@ -21,6 +21,13 @@ module Typhoeus
 
       def cache_ttl
         options[:cache_ttl]
+      end
+
+      private
+
+      def cache
+        return nil if options[:cache] === false
+        options[:cache] || Typhoeus::Config.cache
       end
     end
   end

--- a/spec/typhoeus/request/cacheable_spec.rb
+++ b/spec/typhoeus/request/cacheable_spec.rb
@@ -55,6 +55,30 @@ describe Typhoeus::Request::Cacheable do
           request.run
         end
       end
+
+      context "when cache is specified on a request" do
+        before { Typhoeus::Config.cache = false }
+
+        context "when cache is false" do
+          let(:options) { { cache: false } }
+
+          it "finishes request" do
+            expect(request.response).to_not be(response)
+            request.run
+          end
+        end
+
+        context "when cache is defined" do
+          let(:options) { { cache: cache } }
+
+          before { cache.memory[request] = response }
+
+          it "finishes request" do
+            expect(request).to receive(:finish).with(response)
+            request.run
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Being able to set `Typhoeus::Config.cache` is great but it applies globally and that's not always ideal (e.g. it applies to gems that use Typhoeus and globally to every single request made) but there are cases where we may want to use a different adapter or none at all (e.g. for sensitive requests).

This pull request adds the ability to set a `cache` option when making a request with which you can:

- set it to false to disable caching
- set it to a different adapter