### PR TITLE
Change get to new because otherwise Request.get already returns a response.

### DIFF
--- a/lib/typhoeus/response.rb
+++ b/lib/typhoeus/response.rb
@@ -14,7 +14,7 @@ module Typhoeus
     # Remembers the corresponding request.
     #
     # @example Get request.
-    #   request = Typhoeus::Request.get("www.example.com")
+    #   request = Typhoeus::Request.new("www.example.com")
     #   response = request.run
     #   request == response.request
     #   #=> true


### PR DESCRIPTION
A little documentation bug which makes the example not work.