### PR TITLE
Avoid YARD warnings

### DIFF
--- a/lib/typhoeus.rb
+++ b/lib/typhoeus.rb
@@ -127,11 +127,12 @@ module Typhoeus
   #     #=> :ok
   #   end
   #
-  # @param [ Block ] block The block to execute.
-  #
+  # @yield Yields control to the block after disabling block_connection.
+  #        Afterwards, the block_connection is set to its original
+  #        value.
   # @return [ Object ] Returns the return value of the block.
   #
-  # @see Typhoeus::Config#block_connection
+  # @see Typhoeus::Config.block_connection
   def self.with_connection
     old = Config.block_connection
     Config.block_connection = false

--- a/lib/typhoeus/cache/dalli.rb
+++ b/lib/typhoeus/cache/dalli.rb
@@ -7,7 +7,9 @@ module Typhoeus
       #
       # @param [ Dalli::Client ] client
       #   A connection to the cache server. Defaults to `Dalli::Client.new`
-      # @param [ Integer ] default_ttl
+      # @param [ Hash ] options
+      #   Options
+      # @option options [ Integer ] :default_ttl
       #   The default TTL of cached responses in seconds, for requests which do not set a cache_ttl.
       def initialize(client = ::Dalli::Client.new, options = {})
         @client = client

--- a/lib/typhoeus/cache/rails.rb
+++ b/lib/typhoeus/cache/rails.rb
@@ -7,7 +7,9 @@ module Typhoeus
       #
       # @param [ ActiveSupport::Cache::Store ] cache
       #   A Rails cache backend. Defaults to Rails.cache.
-      # @param [ Integer ] default_ttl
+      # @param [ Hash ] options
+      #   Options
+      # @option options [ Integer ] :default_ttl
       #   The default TTL of cached responses in seconds, for requests which do not set a cache_ttl.
       def initialize(cache = ::Rails.cache, options = {})
         @cache = cache

--- a/lib/typhoeus/cache/redis.rb
+++ b/lib/typhoeus/cache/redis.rb
@@ -8,7 +8,9 @@ module Typhoeus
       # @param [ Redis ] redis
       #   A connection to Redis. Defaults to `Redis.new`, which uses the
       #   `REDIS_URL` environment variable to connect
-      # @param [ Integer ] default_ttl
+      # @param [ Hash ] options
+      #   Options
+      # @option options [ Integer ] :default_ttl
       #   The default TTL of cached responses in seconds, for requests which do not set a cache_ttl.
       def initialize(redis = ::Redis.new, options = {})
         @redis = redis

--- a/lib/typhoeus/config.rb
+++ b/lib/typhoeus/config.rb
@@ -18,7 +18,7 @@ module Typhoeus
     # {Typhoeus::Errors::NoStub} error is raised,
     # when trying to do a real request. It's possible
     # to work around inside
-    # {Typhoeus#with_connection}.
+    # {Typhoeus.with_connection}.
     #
     # @return [ Boolean ]
     #


### PR DESCRIPTION
This PR avoids YARD warnings.

<details>

```
Building YARD (yri) index for typhoeus-1.3.1...
lib/typhoeus.rb:130: [UnknownParam] @param tag has unknown parameter name: block
lib/typhoeus/cache/dalli.rb:10: [UnknownParam] @param tag has unknown parameter name: default_ttl
lib/typhoeus/cache/rails.rb:10: [UnknownParam] @param tag has unknown parameter name: default_ttl
lib/typhoeus/cache/redis.rb:11: [UnknownParam] @param tag has unknown parameter name: default_ttl
```

</details>

# Screenshot

![image](https://user-images.githubusercontent.com/211/55243275-26ddd400-523f-11e9-9be2-9bffc34394b0.png)

Here, it becomes obvious that the option key is a Symbol.