### PR TITLE
CI: Extend and update matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: ruby
 script: "bundle exec rake"
-sudo: false
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.8
-  - 2.2.4
-  - 2.3.0
-  - 2.4.1
+  - 2.1.10
+  - 2.2.10
+  - 2.3.8
+  - 2.4.7
+  - 2.5.6
+  - 2.6.4
   - ruby-head
   - jruby-head
   - jruby-18mode


### PR DESCRIPTION
This PR updates the CI matrix to use latest known releases.

In addition: remove the now-unused `sudo: false` directive. [Blog post about the directive's change to a no-op](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)