### PR TITLE
Fix using an argument in `EasyFactory#sanitize`

### DIFF
--- a/lib/typhoeus/easy_factory.rb
+++ b/lib/typhoeus/easy_factory.rb
@@ -97,7 +97,7 @@ module Typhoeus
       # set nosignal to true by default
       # this improves thread safety and timeout behavior
       sanitized = {:nosignal => true}
-      request.options.each do |k,v|
+      options.each do |k,v|
         s = k.to_sym
         next if SANITIZE_IGNORE.include?(s)
         if new_option = RENAMED_OPTIONS[k.to_sym]


### PR DESCRIPTION
`options` argument isn't used in the method body, but method is called with `request.options` as the argument.
https://github.com/typhoeus/typhoeus/blob/d072aaf6edcf46d54d6a6bce45286629bf4e5af6/lib/typhoeus/easy_factory.rb#L84