### PR TITLE
Use Request caching mechanism in Hydra

### DIFF
--- a/lib/typhoeus/hydra/cacheable.rb
+++ b/lib/typhoeus/hydra/cacheable.rb
@@ -2,7 +2,7 @@ module Typhoeus
   class Hydra
     module Cacheable
       def add(request)
-        if request.cacheable? && response = Typhoeus::Config.cache.get(request)
+        if request.cacheable? && response = request.cached_response
           response.cached = true
           request.finish(response)
           dequeue

--- a/lib/typhoeus/request/cacheable.rb
+++ b/lib/typhoeus/request/cacheable.rb
@@ -11,12 +11,16 @@ module Typhoeus
       end
 
       def run
-        if cacheable? && response = cache.get(self)
+        if response = cached_response
           response.cached = true
           finish(response)
         else
           super
         end
+      end
+
+      def cached_response
+        cacheable? && cache.get(self)
       end
 
       def cache_ttl

--- a/spec/typhoeus/hydra/cacheable_spec.rb
+++ b/spec/typhoeus/hydra/cacheable_spec.rb
@@ -4,6 +4,7 @@ describe Typhoeus::Hydra::Cacheable do
   let(:base_url) { "localhost:3001" }
   let(:hydra) { Typhoeus::Hydra.new() }
   let(:request) { Typhoeus::Request.new(base_url, {:method => :get}) }
+  let(:response) { Typhoeus::Response.new }
   let(:cache) { MemoryCache.new }
 
   describe "add" do
@@ -24,7 +25,6 @@ describe Typhoeus::Hydra::Cacheable do
       end
 
       context "when request in memory" do
-        let(:response) { Typhoeus::Response.new }
         before { cache.memory[request] = response }
 
         it "returns response with cached status" do
@@ -53,6 +53,31 @@ describe Typhoeus::Hydra::Cacheable do
           end
         end
       end
+
+      context "when cache is specified on a request" do
+        before { Typhoeus::Config.cache = false }
+
+        context "when cache is false" do
+          let(:non_cached_request) { Typhoeus::Request.new(base_url, {:method => :get, :cache => false}) }
+
+          it "finishes request" do
+            expect(non_cached_request.response).to_not be_truthy
+            hydra.add(non_cached_request)
+          end
+        end
+
+        context "when cache is defined" do
+          let(:cached_request) { Typhoeus::Request.new(base_url, {:method => :get, :cache => cache}) }
+
+          before { cache.memory[cached_request] = response }
+
+          it "finishes request" do
+            expect(cached_request).to receive(:finish).with(response)
+            hydra.add(cached_request)
+          end
+        end
+      end
+
     end
   end
 end

--- a/spec/typhoeus/hydra/cacheable_spec.rb
+++ b/spec/typhoeus/hydra/cacheable_spec.rb
@@ -60,8 +60,9 @@ describe Typhoeus::Hydra::Cacheable do
         context "when cache is false" do
           let(:non_cached_request) { Typhoeus::Request.new(base_url, {:method => :get, :cache => false}) }
 
-          it "finishes request" do
-            expect(non_cached_request.response).to_not be_truthy
+          it "initiates an HTTP call" do
+            expect(Typhoeus::EasyFactory).to receive(:new).with(non_cached_request, hydra).and_call_original
+
             hydra.add(non_cached_request)
           end
         end
@@ -71,9 +72,13 @@ describe Typhoeus::Hydra::Cacheable do
 
           before { cache.memory[cached_request] = response }
 
-          it "finishes request" do
-            expect(cached_request).to receive(:finish).with(response)
+          it "uses the cache instead of making a new request" do
+            expect(Typhoeus::EasyFactory).not_to receive(:new)
+
             hydra.add(cached_request)
+
+            expect(cached_request.response).to be_cached
+            expect(cached_request.response).to eq(response)
           end
         end
       end


### PR DESCRIPTION
This is related to https://github.com/typhoeus/typhoeus/pull/601 but applied to Hydra queued requests.

When you specify :cache option in a Request, Hydra will always take the Config cache and not the cache option from the Request. This PR fixes this issue.