### PR TITLE
Call `Request#cache_key` to set the key for Rails cache store

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: ruby
 script: "bundle exec rake"
 sudo: false
 rvm:
-  - 1.8.7
-  - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1.8
@@ -20,3 +18,8 @@ matrix:
     - rvm: ruby-head
     - rvm: jruby-head
     - rvm: ree
+  include:
+    - rvm: 1.8.7
+      dist: precise
+    - rvm: 1.9.2
+      dist: trusty

--- a/lib/typhoeus/cache/rails.rb
+++ b/lib/typhoeus/cache/rails.rb
@@ -19,7 +19,7 @@ module Typhoeus
       end
 
       def set(request, response)
-        @cache.write(request, response, :expires_in => request.cache_ttl || @default_ttl)
+        @cache.write(request.cache_key, response, :expires_in => request.cache_ttl || @default_ttl)
       end
     end
   end

--- a/spec/typhoeus/pool_spec.rb
+++ b/spec/typhoeus/pool_spec.rb
@@ -88,12 +88,14 @@ describe Typhoeus::Pool do
 
       context "when threaded access" do
         it "creates correct number of easies" do
-          array = []
+          queue = Queue.new
           (0..9).map do |n|
             Thread.new do
-              array << Typhoeus::Pool.get
+              queue.enq(Typhoeus::Pool.get)
             end
           end.map(&:join)
+
+          array = Array.new(queue.size) { queue.pop }
           expect(array.uniq.size).to eq(10)
         end
       end


### PR DESCRIPTION
Rails [under the hood](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/cache.rb#L653) will call `#cache_key` but it is better to be
explicit since all other cache stores in the project are calling
`cache_key`