### PR TITLE
Add getter for size_upload, size_download, speed_upload, speed_download values

### DIFF
--- a/lib/typhoeus/response/informations.rb
+++ b/lib/typhoeus/response/informations.rb
@@ -214,6 +214,53 @@ module Typhoeus
         options[:request_size]
       end
 
+      # Return the bytes, the total amount of bytes that were uploaded
+      #
+      # @example Get size_upload.
+      #   response.size_upload
+      #
+      # @return [ Float ] The size_upload.
+      def size_upload
+        options[:size_upload]
+      end
+
+
+      # Return the bytes, the total amount of bytes that were downloaded.
+      # The amount is only for the latest transfer and will be reset again
+      # for each new transfer. This counts actual payload data, what's
+      # also commonly called body. All meta and header data are excluded
+      # and will not be counted in this number.
+      #
+      # @example Get size_download
+      #   response.size_download
+      #
+      # @return [ Float ] The size_download.
+      def size_download
+        options[:size_download]
+      end
+
+      # Return the bytes/second, the average upload speed that curl
+      # measured for the complete upload
+      #
+      # @example Get speed_upload.
+      #   response.speed_upload
+      #
+      # @return [ Float ] The speed_upload.
+      def speed_upload
+        options[:speed_upload]
+      end
+
+      # Return the bytes/second, the average download speed that curl
+      # measured for the complete download
+      #
+      # @example Get speed_download.
+      #   response.speed_download
+      #
+      # @return [ Float ] The speed_download.
+      def speed_download
+        options[:speed_download]
+      end
+
       def debug_info
         options[:debug_info]
       end

--- a/spec/typhoeus/response/informations_spec.rb
+++ b/spec/typhoeus/response/informations_spec.rb
@@ -203,6 +203,38 @@ describe Typhoeus::Response::Informations do
     end
   end
 
+  describe "#size_upload" do
+    let(:options) { { :size_upload => 2.0 } }
+
+    it "returns size_upload from options" do
+      expect(response.size_upload).to eq(2.0)
+    end
+  end
+
+  describe "#size_download" do
+    let(:options) { { :size_download => 2.0 } }
+
+    it "returns size_download from options" do
+      expect(response.size_download).to eq(2.0)
+    end
+  end
+
+  describe "#speed_upload" do
+    let(:options) { { :speed_upload => 2.0 } }
+
+    it "returns speed_upload from options" do
+      expect(response.speed_upload).to eq(2.0)
+    end
+  end
+
+  describe "#speed_download" do
+    let(:options) { { :speed_download => 2.0 } }
+
+    it "returns speed_download from options" do
+      expect(response.speed_download).to eq(2.0)
+    end
+  end
+
   describe "#headers" do
     context "when no response_headers" do
       it "returns nil" do


### PR DESCRIPTION
I want this pull request to be merged after [typhoeus/ethon](https://github.com/typhoeus/ethon) [PR#162](https://github.com/typhoeus/ethon/pull/162) is merged
