### PR TITLE
Ensure timeout config vars work if they are strings

### DIFF
--- a/lib/typhoeus/adapters/faraday.rb
+++ b/lib/typhoeus/adapters/faraday.rb
@@ -162,8 +162,8 @@ module Faraday # :nodoc:
 
       def configure_timeout(req, env)
         env_req = env[:request]
-        req.options[:timeout_ms] = env_req[:timeout].to_i * 1000             if env_req[:timeout]
-        req.options[:connecttimeout_ms] = env_req[:open_timeout].to_i * 1000 if env_req[:open_timeout]
+        req.options[:timeout_ms] = (env_req[:timeout].to_f * 1000).to_i             if env_req[:timeout]
+        req.options[:connecttimeout_ms] = (env_req[:open_timeout].to_f * 1000).to_i if env_req[:open_timeout]
       end
 
       def configure_socket(req, env)

--- a/lib/typhoeus/adapters/faraday.rb
+++ b/lib/typhoeus/adapters/faraday.rb
@@ -162,8 +162,8 @@ module Faraday # :nodoc:
 
       def configure_timeout(req, env)
         env_req = env[:request]
-        req.options[:timeout_ms] = (env_req[:timeout] * 1000).to_i             if env_req[:timeout]
-        req.options[:connecttimeout_ms] = (env_req[:open_timeout] * 1000).to_i if env_req[:open_timeout]
+        req.options[:timeout_ms] = env_req[:timeout].to_i * 1000             if env_req[:timeout]
+        req.options[:connecttimeout_ms] = env_req[:open_timeout].to_i * 1000 if env_req[:open_timeout]
       end
 
       def configure_socket(req, env)

--- a/spec/typhoeus/adapters/faraday_spec.rb
+++ b/spec/typhoeus/adapters/faraday_spec.rb
@@ -184,10 +184,20 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("1.9.0")
       before { adapter.method(:configure_timeout).call(request, env) }
 
       context "when timeout" do
-        let(:env) { { :request => { :timeout => 1 } } }
+        context "is an int" do
+          let(:env) { { :request => { :timeout => 1 } } }
 
-        it "sets timeout_ms" do
-          expect(request.options[:timeout_ms]).to eq(1000)
+          it "sets timeout_ms" do
+            expect(request.options[:timeout_ms]).to eq(1000)
+          end
+        end
+
+        context "is a string" do
+          let(:env) { { :request => { :timeout => "1" } } }
+
+          it "sets timeout_ms" do
+            expect(request.options[:timeout_ms]).to eq(1000)
+          end
         end
       end
 

--- a/spec/typhoeus/adapters/faraday_spec.rb
+++ b/spec/typhoeus/adapters/faraday_spec.rb
@@ -199,6 +199,14 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("1.9.0")
             expect(request.options[:timeout_ms]).to eq(1000)
           end
         end
+
+        context "is a float" do
+          let(:env) { { :request => { :timeout => 1.09 } } }
+
+          it "preserves numericality & sets timeout_ms" do
+            expect(request.options[:timeout_ms]).to eq(1090)
+          end
+        end
       end
 
       context "when open_timeout" do


### PR DESCRIPTION
We use Typoheus and accidentally set the timeout configuration env variables as strings. The result was timeout wasn't set correctly (was set to "101010101..." instead).