### PR TITLE
README: Drop mention of mailing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ gem install typhoeus
 
 ## Project Tracking
 
-* [Documentation](http://rubydoc.info/github/typhoeus/typhoeus/frames/Typhoeus) (GitHub master)
-* [Mailing list](http://groups.google.com/group/typhoeus)
+* [API Documentation](https://rubydoc.info/github/typhoeus/typhoeus/frames/Typhoeus) (GitHub master)
 
 ## Usage
 


### PR DESCRIPTION
The last email in 2014 asks the public to use the GitHub Issue tracker for questions.