### PR TITLE
Support for per-request before callbacks

### DIFF
--- a/lib/typhoeus/request/before.rb
+++ b/lib/typhoeus/request/before.rb
@@ -8,6 +8,21 @@ module Typhoeus
     #
     # @api private
     module Before
+      # Set before callback.
+      #
+      # @example Set before.
+      #   request.before { |request| p "yay" }
+      #
+      # @param [ Block ] block The block to execute.
+      #
+      # @yield [ Typhoeus::Request ]
+      #
+      # @return [ Array<Block> ] All before blocks.
+      def before(&block)
+        @before ||= []
+        @before << block if block_given?
+        @before
+      end
 
       # Overrride run in order to execute callbacks in
       # Typhoeus.before. Will break and return when a
@@ -17,7 +32,8 @@ module Typhoeus
       # @example Run the request.
       #   request.run
       def run
-        Typhoeus.before.each do |callback|
+        callbacks = Typhoeus.before + before
+        callbacks.each do |callback|
           value = callback.call(self)
           if value.nil? || value == false || value.is_a?(Response)
             return response

--- a/spec/typhoeus/request/before_spec.rb
+++ b/spec/typhoeus/request/before_spec.rb
@@ -4,9 +4,36 @@ describe Typhoeus::Request::Before do
   let(:request) { Typhoeus::Request.new("") }
   let(:receive_counter) { double :mark => :twain }
 
+  describe '#before' do
+    it 'responds' do
+      expect(request).to respond_to(:before)
+    end
+
+    context 'when no block given' do
+      it 'returns @before' do
+        expect(request.method(:before).call).to eq([])
+      end
+    end
+
+    context 'when block given' do
+      it 'stores' do
+        request.method(:before).call { p 1 }
+        expect(request.instance_variable_get('@before').size).to eq(1)
+      end
+    end
+
+    context 'when multiple blocks given' do
+      it 'stores' do
+        request.method(:before).call { p 1 }
+        request.method(:before).call { p 2 }
+        expect(request.instance_variable_get('@before').size).to eq(2)
+      end
+    end
+  end
+
   describe "#queue" do
     context "when before" do
-      context "when one" do
+      context "when one global" do
         it "executes" do
           Typhoeus.before { |r| receive_counter.mark }
           expect(receive_counter).to receive(:mark)
@@ -48,9 +75,54 @@ describe Typhoeus::Request::Before do
         end
       end
 
+      context "when one local" do
+        it "executes" do
+          request.before { |r| receive_counter.mark }
+          expect(receive_counter).to receive(:mark)
+          request.run
+        end
+
+        context "when true" do
+          it "calls super" do
+            request.before { true }
+            expect(Typhoeus::Expectation).to receive(:response_for)
+            request.run
+          end
+        end
+
+        context "when false" do
+          it "doesn't call super" do
+            request.before { false }
+            expect(Typhoeus::Expectation).to receive(:response_for).never
+            request.run
+          end
+
+          it "returns response" do
+            request.before { |r| r.response = 1; false }
+            expect(request.run).to be(1)
+          end
+        end
+
+        context "when a response" do
+          it "doesn't call super" do
+            request.before { Typhoeus::Response.new }
+            expect(Typhoeus::Expectation).to receive(:response_for).never
+            request.run
+          end
+
+          it "returns response" do
+            request.before { |r| r.response = Typhoeus::Response.new }
+            expect(request.run).to be_a(Typhoeus::Response)
+          end
+        end
+      end
+
       context "when multi" do
         context "when all true" do
-          before { 3.times { Typhoeus.before { |r| receive_counter.mark } } }
+          before { 
+            3.times { Typhoeus.before { |r| receive_counter.mark } }
+            3.times { request.before { |r| receive_counter.mark } }
+          }
 
           it "calls super" do
             expect(Typhoeus::Expectation).to receive(:response_for)
@@ -58,16 +130,17 @@ describe Typhoeus::Request::Before do
           end
 
           it "executes all" do
-            expect(receive_counter).to receive(:mark).exactly(3)
+            expect(receive_counter).to receive(:mark).exactly(6)
             request.run
           end
         end
 
-        context "when middle false" do
+        context "when global middle false" do
           before do
             Typhoeus.before { |r| receive_counter.mark }
             Typhoeus.before { |r| receive_counter.mark; nil }
             Typhoeus.before { |r| receive_counter.mark }
+            request.before { |r| recieve_counter.mark }
           end
 
           it "doesn't call super" do
@@ -77,6 +150,25 @@ describe Typhoeus::Request::Before do
 
           it "executes only two" do
             expect(receive_counter).to receive(:mark).exactly(2).times
+            request.run
+          end
+        end
+
+        context "when instance middle false" do
+          before do
+            Typhoeus.before { |r| receive_counter.mark }
+            request.before { |r| receive_counter.mark; nil }
+            Typhoeus.before { |r| receive_counter.mark }
+            request.before { |r| recieve_counter.mark }
+          end
+
+          it "doesn't call super" do
+            expect(Typhoeus::Expectation).to receive(:response_for).never
+            request.run
+          end
+
+          it "executes only three" do
+            expect(receive_counter).to receive(:mark).exactly(3).times
             request.run
           end
         end


### PR DESCRIPTION
Adds support for per-request `before` callback to Typheous requests. These callbacks are executed after the global `Typheous.before` callbacks.