### PR TITLE
Allow verifyhost to be independent of verifypeer

### DIFF
--- a/lib/typhoeus/adapters/faraday.rb
+++ b/lib/typhoeus/adapters/faraday.rb
@@ -136,7 +136,12 @@ module Faraday # :nodoc:
 
         verify_p = (ssl && ssl.fetch(:verify, true))
 
-        ssl_verifyhost = verify_p ? 2 : 0
+        if verify_p
+          ssl_verifyhost = req.options.fetch(:ssl_verifyhost, 2)
+        else
+          ssl_verifyhost = 0
+        end
+
         req.options[:ssl_verifyhost] = ssl_verifyhost
         req.options[:ssl_verifypeer] = verify_p
         req.options[:sslversion] = ssl[:version]     if ssl[:version]

--- a/spec/typhoeus/adapters/faraday_spec.rb
+++ b/spec/typhoeus/adapters/faraday_spec.rb
@@ -305,6 +305,15 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("1.9.0")
         end
       end
 
+      context "when verify is false but ssl_verifyhost is 2" do
+        let(:request) { Typhoeus::Request.new(base_url, ssl_verifyhost: 2) }
+        let(:env) { { :ssl => { :verify => false } } }
+
+        it "sets ssl_verifyhost to 0" do
+          expect(request.options[:ssl_verifyhost]).to eq(0)
+        end
+      end
+
       context "when verify is true" do
         let(:env) { { :ssl => { :verify => true } } }
 
@@ -314,6 +323,24 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("1.9.0")
 
         it "sets ssl_verifypeer to true" do
           expect(request.options[:ssl_verifypeer]).to be_truthy
+        end
+      end
+
+      context "when verify is true and ssl_verifyhost is 2" do
+        let(:request) { Typhoeus::Request.new(base_url, ssl_verifyhost: 2) }
+        let(:env) { { :ssl => { :verify => true } } }
+
+        it "sets ssl_verifyhost to 2" do
+          expect(request.options[:ssl_verifyhost]).to eq(2)
+        end
+      end
+
+      context "when verify is true but ssl_verifyhost is 0" do
+        let(:request) { Typhoeus::Request.new(base_url, ssl_verifyhost: 0) }
+        let(:env) { { :ssl => { :verify => true } } }
+
+        it "sets ssl_verifyhost to 0" do
+          expect(request.options[:ssl_verifyhost]).to eq(0)
         end
       end
     end


### PR DESCRIPTION
Prior to this change it wasn't possible to control libcurl's
`ssl_verifyhost` setting independently to its `ssl_verifypeer` setting
when using Typhoeus as a Faraday adapter. It's a not uncommon
situation to want the peer certificate and its chain to be verified, but
to not want to enforce the certicate's CN/SAN-DNS entries match the
hostname of the peer; hence these being two separate options in libcurl.

This change keeps the existing default behaviour of setting
`ssl_verifyhost` to 2 if Faraday's ssl `verify` option is true, and 0
otherwise. However if the `verify` setting is true and `ssl_verifyhost`
has been supplied in the `adapter_options`, then the supplied value is
used.

For example:

```
Faraday.new(url, ssl: {verify: true}) do |faraday|
  faraday.adapter  :typhoeus, ssl_verifyhost: 0
end
```

While it would make sense for the `ssl_verifyhost` option to be supplied
as part of the ssl parameters to the adapter itself, that requires
support in Faraday. I think this approach follows the expected behaviour
of adapters accepting non-standard Faraday options in the
`adapter_options` hash.