### PR TITLE
Add max_version and min_version params to Faraday adapter

### DIFF
--- a/lib/typhoeus/adapters/faraday.rb
+++ b/lib/typhoeus/adapters/faraday.rb
@@ -140,6 +140,8 @@ module Faraday # :nodoc:
         req.options[:ssl_verifyhost] = ssl_verifyhost
         req.options[:ssl_verifypeer] = verify_p
         req.options[:sslversion] = ssl[:version]     if ssl[:version]
+        req.options[:sslmaxversion] = ssl[:max_version]     if ssl[:max_version]
+        req.options[:sslminversion] = ssl[:min_version]     if ssl[:min_version]
         req.options[:sslcert]    = ssl[:client_cert] if ssl[:client_cert]
         req.options[:sslkey]     = ssl[:client_key]  if ssl[:client_key]
         req.options[:cainfo]     = ssl[:ca_file]     if ssl[:ca_file]

--- a/spec/typhoeus/adapters/faraday_spec.rb
+++ b/spec/typhoeus/adapters/faraday_spec.rb
@@ -237,6 +237,22 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("1.9.0")
         end
       end
 
+      context "when max version" do
+        let(:env) { { :ssl => { :max_version => "a" } } }
+
+        it "sets sslmaxversion" do
+          expect(request.options[:sslmaxversion]).to eq("a")
+        end
+      end
+
+      context "when min version" do
+        let(:env) { { :ssl => { :min_version => "a" } } }
+
+        it "sets sslminversion" do
+          expect(request.options[:sslminversion]).to eq("a")
+        end
+      end
+
       context "when client_cert" do
         let(:env) { { :ssl => { :client_cert => "a" } } }
 


### PR DESCRIPTION
This makes available max_version and min_version from Faraday SSL options https://www.rubydoc.info/github/lostisland/faraday/Faraday/SSLOptions