### PR TITLE
feat: add Typhoeus::Response::Status#complete?

### DIFF
--- a/lib/typhoeus/response/status.rb
+++ b/lib/typhoeus/response/status.rb
@@ -79,6 +79,16 @@ module Typhoeus
         return_code == :operation_timedout
       end
 
+      # Return whether the response has been completed.
+      #
+      # @example Return if the response has been completed.
+      #  response.complete?
+      #
+      # @return [ Boolean ] Return true if not timed out and a valid status code, false else.
+      def complete?
+        response_code != 0 && !timed_out?
+      end
+
       private
 
       # :nodoc:

--- a/spec/typhoeus/response/status_spec.rb
+++ b/spec/typhoeus/response/status_spec.rb
@@ -74,6 +74,33 @@ describe Typhoeus::Response::Status do
     end
   end
 
+  describe "#complete?" do
+    subject(:complete?) { response.complete? }
+
+    let(:options) { {:return_code => return_code, :response_code => response_code} }
+
+    context "when response code 200-299" do
+      let(:return_code) { :ok }
+      let(:response_code) { 200 }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "when response code 0" do
+      let(:return_code) { :ok }
+      let(:response_code) { 0 }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "when return_code :operation_timedout" do
+      let(:return_code) { :operation_timedout }
+      let(:response_code) { 200 }
+
+      it { is_expected.to eq(false) }
+    end
+  end
+
   describe "#success?" do
     context "when response code 200-299" do
       let(:options) { {:return_code => return_code, :response_code => 201} }


### PR DESCRIPTION
Helper to determine that some status code was returned and the operation did not timeout.