### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,8 @@ Typhoeus.get("www.example.com").cached?
 For use with [Dalli](https://github.com/mperham/dalli):
 
 ```ruby
+require "typhoeus/cache/dalli"
+
 dalli = Dalli::Client.new(...)
 Typhoeus::Config.cache = Typhoeus::Cache::Dalli.new(dalli)
 ```
@@ -356,12 +358,16 @@ Typhoeus::Config.cache = Typhoeus::Cache::Dalli.new(dalli)
 For use with Rails:
 
 ```ruby
+require "typhoeus/cache/rails"
+
 Typhoeus::Config.cache = Typhoeus::Cache::Rails.new
 ```
 
 For use with [Redis](https://github.com/redis/redis-rb):
 
 ```ruby
+require "typhoeus/cache/redis"
+
 redis = Redis.new(...)
 Typhoeus::Config.cache = Typhoeus::Cache::Redis.new(redis)
 ```


### PR DESCRIPTION
# Summary
require relevant caching file before using to avoid "**uninitialized constant Typhoeus::Cache**"

---
## Details
If we just do:
```ruby
require "typhoeus"
require "redis"

redis = Redis.new
Typhoeus::Config.cache = Typhoeus::Cache::Redis.new(redis)
```
it raise error:
```
=> uninitialized constant Typhoeus::Cache (NameError)
```

and it gets fixed by requiring respective file before using it
```ruby
require "typhoeus"
require "redis"
require "typhoeus/cache/redis" # Add here 

redis = Redis.new
Typhoeus::Config.cache = Typhoeus::Cache::Redis.new(redis)
```