### PR TITLE
Add global timeout and connecttimeout to config

### DIFF
--- a/lib/typhoeus/config.rb
+++ b/lib/typhoeus/config.rb
@@ -44,6 +44,22 @@ module Typhoeus
     # @see http://curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTVERBOSE
     attr_accessor :verbose
 
+    # Defines the default HTTP timeout for the entire request in seconds
+    # See README for more details about timeouts
+    #
+    # @return [ Integer, Float ]
+    #
+    # @see https://curl.haxx.se/libcurl/c/curl_easy_setopt#CURLOPTTIMEOUT
+    attr_accessor :timeout
+
+    # Defines the default HTTP timeout for the connection phase in seconds
+    # See README for more details about timeouts
+    #
+    # @return [ Integer, Float ]
+    #
+    # @see https://curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTCONNECTTIMEOUT
+    attr_accessor :connecttimeout
+
     # Defines whether requests are cached.
     #
     # @return [ Object ]

--- a/lib/typhoeus/request.rb
+++ b/lib/typhoeus/request.rb
@@ -214,6 +214,8 @@ module Typhoeus
       options[:headers] = {'User-Agent' => default_user_agent}.merge(options[:headers] || {})
       options[:headers]['Expect'] ||= ''
       options[:verbose] = Typhoeus::Config.verbose if options[:verbose].nil? && !Typhoeus::Config.verbose.nil?
+      options[:timeout] = Typhoeus::Config.timeout if options[:timeout].nil? && !Typhoeus::Config.timeout.nil?
+      options[:connecttimeout] = Typhoeus::Config.connecttimeout if options[:connecttimeout].nil? && !Typhoeus::Config.connecttimeout.nil?
       options[:maxredirs] ||= 50
       options[:proxy] = Typhoeus::Config.proxy unless options.has_key?(:proxy) || Typhoeus::Config.proxy.nil?
     end

--- a/spec/typhoeus/request_spec.rb
+++ b/spec/typhoeus/request_spec.rb
@@ -2,7 +2,13 @@ require 'spec_helper'
 
 describe Typhoeus::Request do
   let(:base_url) { "localhost:3001" }
-  let(:options) { {:verbose => true, :headers => { 'User-Agent' => "Fubar", 'Expect' => "" }, :maxredirs => 50} }
+  let(:options) do
+    {
+      verbose: true,
+      headers: { "User-Agent" => "Fubar", "Expect" => "" },
+      maxredirs: 50
+    }
+  end
   let(:request) { Typhoeus::Request.new(base_url, options) }
 
   describe ".url" do
@@ -92,6 +98,24 @@ describe Typhoeus::Request do
 
       it "respects" do
         expect(request.options[:verbose]).to be_truthy
+      end
+    end
+
+    context "when Config.timeout set" do
+      before { Typhoeus.configure { |config| config.timeout = 10 } }
+      after { Typhoeus.configure { |config| config.timeout = nil } }
+
+      it "respects configuration" do
+        expect(request.options[:timeout]).to eq(10)
+      end
+    end
+
+    context "when Config.connecttimeout set" do
+      before { Typhoeus.configure { |config| config.connecttimeout = 10 } }
+      after { Typhoeus.configure { |config| config.connecttimeout = nil } }
+
+      it "respects configuration" do
+        expect(request.options[:connecttimeout]).to eq(10)
       end
     end
 


### PR DESCRIPTION
This PR allows setting a global timeout and connecttimeout configuration. A retake of #626, with test suites passsing. Thanks to @mkaplan9! I've added you as a co-author.