### PR TITLE
Add support for streaming to faraday adapter

### DIFF
--- a/spec/support/server.rb
+++ b/spec/support/server.rb
@@ -85,6 +85,16 @@ TESTSERVER = Sinatra.new do
     gzipped_env
   end
 
+  get '/empty' do
+    [200, { 'Content-Type' => 'text/plain' }, ['']]
+  end
+
+  get '/big' do
+    kb = 1024
+    str = (32..126).map(&:chr).cycle.take(50 * kb).join
+    [200, { 'Content-Type' => 'text/plain', 'X-Expected-Size' => str.bytesize.to_s }, [str]]
+  end
+
   get '/**' do
     sleep params["delay"].to_i if params.has_key?("delay")
     request.env.merge!(:body => request.body.read).to_json


### PR DESCRIPTION
This allows Typhoeus to stream the response body using Faraday's `on_data` callback, similar to the way it works in `Net::HTTP`: https://lostisland.github.io/faraday/usage/streaming

This is preliminary; I haven't tested it in conjunction with other features of Typhoeus (e.g. parallel requests). The tests are pretty simple too.

Let me know if there is any documentation that should be written in this repo.