### PR TITLE
Use bundle add instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,10 @@ hydra.run
 ```
 
 ## Installation
-Add the following line to your Gemfile:
+Run:
 ```
-gem "typhoeus"
+bundle add typhoeus
 ```
-Then run `bundle install`
 
 Or install it yourself as:
 


### PR DESCRIPTION
As per https://github.com/rubygems/rubygems/pull/5337, we can simplify the steps of adding a gem.