### PR TITLE
Added getter for `redirect_url` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 [Full Changelog](http://github.com/typhoeus/typhoeus/compare/v1.4.0...master)
 
+* Added getter for `redirect_url` value.
+  ([Adrien Rey-Jarthon](https://github.com/jarthod))
+
 ## 1.4.0
 
 [Full Changelog](http://github.com/typhoeus/typhoeus/compare/v1.1.2...v1.4.0)

--- a/lib/typhoeus/response/informations.rb
+++ b/lib/typhoeus/response/informations.rb
@@ -210,6 +210,16 @@ module Typhoeus
         options[:redirect_count]
       end
 
+      # Return the URL a redirect would take you to, had you enabled redirects.
+      #
+      # @example Get redirect_url.
+      #   response.redirect_url
+      #
+      # @return [ String ] The redirect_url.
+      def redirect_url
+        options[:redirect_url]
+      end
+
       def request_size
         options[:request_size]
       end

--- a/spec/typhoeus/response/informations_spec.rb
+++ b/spec/typhoeus/response/informations_spec.rb
@@ -195,6 +195,14 @@ describe Typhoeus::Response::Informations do
     end
   end
 
+  describe "#redirect_url" do
+    let(:options) { { :redirect_url => "http://www.example.com" } }
+
+    it "returns redirect_url from options" do
+      expect(response.redirect_url).to eq("http://www.example.com")
+    end
+  end
+
   describe "#request_size" do
     let(:options) { { :request_size => 2 } }
 


### PR DESCRIPTION
Similar to my previous PR (#436), this PR depends on https://github.com/typhoeus/ethon/pull/215 (which adds the `redirect_url` to ethon) and simply adds the getter to typhoeus. I did not raise the required ethon version because it seems to work fine with previous versions (the attribute is simply `nil`).

I tested both projects together (this branch with ethon master) and I get the correct reading for `redirect_url` +1