### PR TITLE
Fix to run CI with Ruby 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        ruby-version: [2.5, 2.6, 2.7, 3.0, 3.1, truffleruby]
+        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', truffleruby]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install libcurl header
         run: |
           if ${{ matrix.os == 'macos' }}

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -14,7 +14,7 @@ jobs:
           - jruby-head
           - truffleruby-head
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install libcurl header
         run: |
           if ${{ matrix.os == 'macos' }}


### PR DESCRIPTION
Using 3.0 without quotes, `ruby/setup-ruby` will use 3.1 instead of 3.0.
To avoid similar parsing issues, all version numbers are enclosed in quotes.
Please see https://github.com/ruby/setup-ruby/issues/252 for more details.

`actions/checkout` were also bumped from v2 to v3.