### PR TITLE
Fix typo in comment

### DIFF
--- a/lib/typhoeus/request/responseable.rb
+++ b/lib/typhoeus/request/responseable.rb
@@ -1,7 +1,7 @@
 module Typhoeus
   class Request
 
-    # This module contains logic for having a reponse
+    # This module contains logic for having a response
     # getter and setter.
     module Responseable
 


### PR DESCRIPTION
Just a very tiny documentation update: reponse => response 🙂 