### PR TITLE
Expectation: Expose response_counter for use in testing

### DIFF
--- a/lib/typhoeus/expectation.rb
+++ b/lib/typhoeus/expectation.rb
@@ -49,6 +49,17 @@ module Typhoeus
     # @api private
     attr_reader :from
 
+    # Whenever an expectation is triggered this counter increases which can be used in testing to ensure that a defined stub is actually used.
+    #
+    # @example Stub a request and check if it was used
+    #   expected = Typhoeus::Response.new
+    #   Typhoeus.stub("www.example.com").and_return(expected)
+    #
+    #   actual = Typhoeus.get("www.example.com")
+    #   expect(expected.response_counter).to eq 1
+    #   #=> true
+    attr_reader :response_counter
+
     class << self
 
       # Returns all expectations.


### PR DESCRIPTION
It can be beneficial / necessary to check if a defined stub was actually called. There already is an response_counter in place that increments on every use, which is currently only used internally to handle Arrays of responses.

This MR make the `response_counter` accessible via `attr_reader` so you can do things like this:

```ruby
require 'typhoeus'

RSpec.describe "Sample" do
  it "can check if a request was called" do
    expectation = Typhoeus.stub("https://example.com") do
      Typhoeus::Response.new(code: 204)
    end

    Typhoeus.get "https://example.com"

    expect(expectation.response_counter).to eq 1
  end
end
```