### PR TITLE
CI against latest Rubies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', truffleruby]
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', truffleruby]
     steps:
       - uses: actions/checkout@v3
       - name: Install libcurl header

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2', truffleruby]
+        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', truffleruby]
     steps:
       - uses: actions/checkout@v3
       - name: Install libcurl header

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', truffleruby]
+        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2', truffleruby]
     steps:
       - uses: actions/checkout@v3
       - name: Install libcurl header

--- a/typhoeus.gemspec
+++ b/typhoeus.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.license = 'MIT'
 
-  s.add_dependency('ethon', [">= 0.9.0"])
+  s.add_dependency('ethon', [">= 0.9.0", "< 0.16.0"])
 
   s.files        = `git ls-files`.split("\n")
   s.test_files   = `git ls-files -- spec/*`.split("\n")


### PR DESCRIPTION
This PR adds Ruby 3.2 and Ruby 3.3 to the CI matrix.
I confirmed the CI is passed on my fork. https://github.com/y-yagi/typhoeus/pull/1

Also, I dropped Ruby 2.5 from the CI matrix. This is because ruby-build doesn't provide Ruby 2.5 on macos 13.
https://github.com/y-yagi/typhoeus/actions/runs/9183698809/job/25254830322?pr=1#step:4:16
I think v2.5 is too old to keep support.

