### PR TITLE
TEST: support curl 8.9 error message

### DIFF
--- a/spec/typhoeus/response/informations_spec.rb
+++ b/spec/typhoeus/response/informations_spec.rb
@@ -24,7 +24,7 @@ describe Typhoeus::Response::Informations do
     let(:options) { { :return_code => :couldnt_connect } }
 
     it "returns a message" do
-      expect(response.return_message).to eq("Couldn't connect to server")
+      expect(response.return_message).to match(/(Couldn't|Could not) connect to server/)
     end
 
     describe "with nil return_code" do


### PR DESCRIPTION
With
https://github.com/curl/curl/commit/c074ba64a86c36bbb697b89e1b3509fd14d12af3 curl changes the error message with CURLE_COULDNT_CONNECT and so on. Modify typheous side test code to support this curl change.

Closes #723 .