### PR TITLE
CI against Ruby 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', truffleruby]
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', truffleruby]
     steps:
       - uses: actions/checkout@v3
       - name: Install libcurl header


### PR DESCRIPTION
This PR adds Ruby 3.4 CI matrix to confirm `typhoeus` working with it.
