### PR TITLE
fix #662: handle URI object in Expectation::url_match?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [Full Changelog](http://github.com/typhoeus/typhoeus/compare/v1.4.0...master)
 
+* Added support for URI objects in `Typhoeus.stub()`.
+  ([Katelyn Schiesser](https://github.com/slowbro), [#732](https://github.com/typhoeus/typhoeus/pull/732))
 * Added getter for `redirect_url` value.
   ([Adrien Rey-Jarthon](https://github.com/jarthod))
 

--- a/lib/typhoeus/expectation.rb
+++ b/lib/typhoeus/expectation.rb
@@ -207,6 +207,8 @@ module Typhoeus
         base_url == request_url
       when Regexp
         base_url === request_url
+      when URI
+        base_url === request_url
       when nil
         true
       else

--- a/lib/typhoeus/expectation.rb
+++ b/lib/typhoeus/expectation.rb
@@ -204,11 +204,11 @@ module Typhoeus
     def url_match?(request_url)
       case base_url
       when String
-        base_url == request_url
+        base_url == request_url.to_s
       when Regexp
-        base_url === request_url
-      when URI
-        base_url === request_url
+        base_url === request_url.to_s
+      when defined?(URI) && URI
+        base_url.to_s == request_url.to_s
       when nil
         true
       else

--- a/spec/typhoeus/expectation_spec.rb
+++ b/spec/typhoeus/expectation_spec.rb
@@ -212,11 +212,10 @@ describe Typhoeus::Expectation do
     end
 
     context "when URI" do
-      let(:request_url) { URI("http://www.example.com") }
-      let(:request) { Typhoeus::Request.new(request_url) }
+      let(:base_url) { URI("https://example.com") }
 
       context "when match" do
-        let(:base_url) { URI("http://www.example.com") }
+        let(:request_url) { "https://example.com" }
 
         it "returns true" do
           expect(url_match).to be_truthy
@@ -224,18 +223,10 @@ describe Typhoeus::Expectation do
       end
 
       context "when no match" do
-        let(:base_url) { URI("http://www.notexample.com") }
+        let(:request_url) { "https://nomatch.com" }
 
         it "returns false" do
           expect(url_match).to be_falsey
-        end
-
-        context "with nil request_url" do
-          let(:request_url) { nil }
-
-          it "returns false" do
-            expect(url_match).to be_falsey
-          end
         end
       end
     end

--- a/spec/typhoeus/expectation_spec.rb
+++ b/spec/typhoeus/expectation_spec.rb
@@ -211,6 +211,35 @@ describe Typhoeus::Expectation do
       end
     end
 
+    context "when URI" do
+      let(:request_url) { URI("http://www.example.com") }
+      let(:request) { Typhoeus::Request.new(request_url) }
+
+      context "when match" do
+        let(:base_url) { URI("http://www.example.com") }
+
+        it "returns true" do
+          expect(url_match).to be_truthy
+        end
+      end
+
+      context "when no match" do
+        let(:base_url) { URI("http://www.notexample.com") }
+
+        it "returns false" do
+          expect(url_match).to be_falsey
+        end
+
+        context "with nil request_url" do
+          let(:request_url) { nil }
+
+          it "returns false" do
+            expect(url_match).to be_falsey
+          end
+        end
+      end
+    end
+
     context "when nil" do
       let(:base_url) { nil }
 

--- a/spec/typhoeus_spec.rb
+++ b/spec/typhoeus_spec.rb
@@ -62,6 +62,18 @@ describe Typhoeus do
         expect(Typhoeus::Expectation.all.size).to eq(1)
       end
     end
+
+    context "when base_url is URI" do
+      it "stubs and matches URI base_url" do
+        uri = URI("https://example.com")
+        expected_response = Typhoeus::Response.new(body: "stubbed")
+
+        Typhoeus.stub(uri).and_return(expected_response)
+        response = Typhoeus.get(uri)
+
+        expect(response.body).to eq("stubbed")
+      end
+    end
   end
 
   describe ".before" do


### PR DESCRIPTION
Fixes #662 - stubbing a request whose base_url is a URI object always returns false. This adds a check in the `case` statement to check for URI matches.

Let me know if this was the desired solution, @felipedmesquita :)