### PR TITLE
Enable Frozen String Literals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,7 @@ jobs:
           bundler-cache: true
       - name: Run tests
         run: |
+          if [[ $(ruby -e 'puts RUBY_ENGINE') == 'ruby' ]]; then
+            export RUBYOPT='--enable=frozen-string-literal --debug=frozen-string-literal'
+          fi
           bundle exec rake

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -30,4 +30,7 @@ jobs:
           bundler-cache: true
       - name: Run tests
         run: |
+          if [[ $(ruby -e 'puts RUBY_ENGINE') == 'ruby' ]]; then
+            export RUBYOPT='--enable=frozen-string-literal --debug=frozen-string-literal'
+          fi
           bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 gemspec
 

--- a/Guardfile
+++ b/Guardfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # vim:set filetype=ruby:
 guard(
   "rspec",

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler"
 Bundler.setup
 

--- a/lib/rack/typhoeus.rb
+++ b/lib/rack/typhoeus.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require "rack/typhoeus/middleware/params_decoder"

--- a/lib/rack/typhoeus/middleware/params_decoder.rb
+++ b/lib/rack/typhoeus/middleware/params_decoder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rack/typhoeus/middleware/params_decoder/helper'
 
 module Rack

--- a/lib/rack/typhoeus/middleware/params_decoder/helper.rb
+++ b/lib/rack/typhoeus/middleware/params_decoder/helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   module Typhoeus
     module Middleware

--- a/lib/typhoeus.rb
+++ b/lib/typhoeus.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'digest/sha2'
 require 'ethon'
 

--- a/lib/typhoeus/adapters/faraday.rb
+++ b/lib/typhoeus/adapters/faraday.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'faraday'
 
 module Faraday # :nodoc:

--- a/lib/typhoeus/cache/dalli.rb
+++ b/lib/typhoeus/cache/dalli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   module Cache
     # This module provides a simple way to cache HTTP responses using Dalli.

--- a/lib/typhoeus/cache/rails.rb
+++ b/lib/typhoeus/cache/rails.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   module Cache
     # This module provides a simple way to cache HTTP responses in using the Rails cache.

--- a/lib/typhoeus/cache/redis.rb
+++ b/lib/typhoeus/cache/redis.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   module Cache
     # This module provides a simple way to cache HTTP responses in Redis.

--- a/lib/typhoeus/config.rb
+++ b/lib/typhoeus/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
 
   # The Typhoeus configuration used to set global

--- a/lib/typhoeus/easy_factory.rb
+++ b/lib/typhoeus/easy_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module Typhoeus

--- a/lib/typhoeus/errors.rb
+++ b/lib/typhoeus/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'typhoeus/errors/typhoeus_error'
 require 'typhoeus/errors/no_stub'
 

--- a/lib/typhoeus/errors/no_stub.rb
+++ b/lib/typhoeus/errors/no_stub.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   module Errors
 

--- a/lib/typhoeus/errors/typhoeus_error.rb
+++ b/lib/typhoeus/errors/typhoeus_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   module Errors
 

--- a/lib/typhoeus/expectation.rb
+++ b/lib/typhoeus/expectation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
 
   # This class represents an expectation. It is part

--- a/lib/typhoeus/hydra.rb
+++ b/lib/typhoeus/hydra.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'typhoeus/hydra/addable'
 require 'typhoeus/hydra/before'
 require 'typhoeus/hydra/cacheable'

--- a/lib/typhoeus/hydra/addable.rb
+++ b/lib/typhoeus/hydra/addable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   class Hydra
 

--- a/lib/typhoeus/hydra/before.rb
+++ b/lib/typhoeus/hydra/before.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   class Hydra
 

--- a/lib/typhoeus/hydra/block_connection.rb
+++ b/lib/typhoeus/hydra/block_connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   class Hydra
 

--- a/lib/typhoeus/hydra/cacheable.rb
+++ b/lib/typhoeus/hydra/cacheable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   class Hydra
     module Cacheable

--- a/lib/typhoeus/hydra/memoizable.rb
+++ b/lib/typhoeus/hydra/memoizable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   class Hydra
 

--- a/lib/typhoeus/hydra/queueable.rb
+++ b/lib/typhoeus/hydra/queueable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   class Hydra
 

--- a/lib/typhoeus/hydra/runnable.rb
+++ b/lib/typhoeus/hydra/runnable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   class Hydra
 

--- a/lib/typhoeus/hydra/stubbable.rb
+++ b/lib/typhoeus/hydra/stubbable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   class Hydra
 

--- a/lib/typhoeus/pool.rb
+++ b/lib/typhoeus/pool.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 
 module Typhoeus

--- a/lib/typhoeus/railtie.rb
+++ b/lib/typhoeus/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "typhoeus"
 
 module Rails

--- a/lib/typhoeus/request.rb
+++ b/lib/typhoeus/request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'zlib'
 require 'digest/sha1'
 require 'typhoeus/request/actions'

--- a/lib/typhoeus/request/actions.rb
+++ b/lib/typhoeus/request/actions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   class Request
 

--- a/lib/typhoeus/request/before.rb
+++ b/lib/typhoeus/request/before.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   class Request
 

--- a/lib/typhoeus/request/block_connection.rb
+++ b/lib/typhoeus/request/block_connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   class Request
 

--- a/lib/typhoeus/request/cacheable.rb
+++ b/lib/typhoeus/request/cacheable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   class Request
     module Cacheable

--- a/lib/typhoeus/request/callbacks.rb
+++ b/lib/typhoeus/request/callbacks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   class Request
 

--- a/lib/typhoeus/request/marshal.rb
+++ b/lib/typhoeus/request/marshal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   class Request
 

--- a/lib/typhoeus/request/memoizable.rb
+++ b/lib/typhoeus/request/memoizable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   class Request
 

--- a/lib/typhoeus/request/operations.rb
+++ b/lib/typhoeus/request/operations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   class Request
 

--- a/lib/typhoeus/request/responseable.rb
+++ b/lib/typhoeus/request/responseable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   class Request
 

--- a/lib/typhoeus/request/streamable.rb
+++ b/lib/typhoeus/request/streamable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   class Request
 

--- a/lib/typhoeus/request/stubbable.rb
+++ b/lib/typhoeus/request/stubbable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   class Request
 

--- a/lib/typhoeus/response.rb
+++ b/lib/typhoeus/response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'typhoeus/response/header'
 require 'typhoeus/response/informations'
 require 'typhoeus/response/status'

--- a/lib/typhoeus/response/cacheable.rb
+++ b/lib/typhoeus/response/cacheable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   class Response
     module Cacheable

--- a/lib/typhoeus/response/header.rb
+++ b/lib/typhoeus/response/header.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'delegate'
 
 module Typhoeus

--- a/lib/typhoeus/response/informations.rb
+++ b/lib/typhoeus/response/informations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   class Response
 

--- a/lib/typhoeus/response/status.rb
+++ b/lib/typhoeus/response/status.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
   class Response
 

--- a/lib/typhoeus/version.rb
+++ b/lib/typhoeus/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Typhoeus
 
   # The current Typhoeus version.

--- a/perf/profile.rb
+++ b/perf/profile.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'typhoeus'
 require 'ruby-prof'
 

--- a/perf/vs_nethttp.rb
+++ b/perf/vs_nethttp.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'typhoeus'
 require 'net/http'
 require 'open-uri'

--- a/spec/rack/typhoeus/middleware/params_decoder/helper_spec.rb
+++ b/spec/rack/typhoeus/middleware/params_decoder/helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require "rack/typhoeus"
 

--- a/spec/rack/typhoeus/middleware/params_decoder_spec.rb
+++ b/spec/rack/typhoeus/middleware/params_decoder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe "Rack::Typhoeus::Middleware::ParamsDecoder" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 

--- a/spec/support/localhost_server.rb
+++ b/spec/support/localhost_server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rack'
 require 'rack/handler/webrick'
 require 'net/http'

--- a/spec/support/memory_cache.rb
+++ b/spec/support/memory_cache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MemoryCache
   attr_reader :memory
 

--- a/spec/support/server.rb
+++ b/spec/support/server.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'json'
 require 'zlib'
 require 'sinatra/base'

--- a/spec/typhoeus/adapters/faraday_spec.rb
+++ b/spec/typhoeus/adapters/faraday_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("1.9.0")
   require 'spec_helper'
   require 'typhoeus/adapters/faraday'

--- a/spec/typhoeus/cache/dalli_spec.rb
+++ b/spec/typhoeus/cache/dalli_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("1.9.0")
   require 'dalli'
   require 'typhoeus/cache/dalli'

--- a/spec/typhoeus/cache/redis_spec.rb
+++ b/spec/typhoeus/cache/redis_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'redis'
 require 'typhoeus/cache/redis'
 require 'spec_helper'

--- a/spec/typhoeus/config_spec.rb
+++ b/spec/typhoeus/config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Config do

--- a/spec/typhoeus/easy_factory_spec.rb
+++ b/spec/typhoeus/easy_factory_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::EasyFactory do

--- a/spec/typhoeus/errors/no_stub_spec.rb
+++ b/spec/typhoeus/errors/no_stub_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Errors::NoStub do

--- a/spec/typhoeus/expectation_spec.rb
+++ b/spec/typhoeus/expectation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Expectation do

--- a/spec/typhoeus/hydra/addable_spec.rb
+++ b/spec/typhoeus/hydra/addable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Hydra::Addable do

--- a/spec/typhoeus/hydra/before_spec.rb
+++ b/spec/typhoeus/hydra/before_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Hydra::Before do

--- a/spec/typhoeus/hydra/block_connection_spec.rb
+++ b/spec/typhoeus/hydra/block_connection_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Hydra::BlockConnection do

--- a/spec/typhoeus/hydra/cacheable_spec.rb
+++ b/spec/typhoeus/hydra/cacheable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Hydra::Cacheable do

--- a/spec/typhoeus/hydra/memoizable_spec.rb
+++ b/spec/typhoeus/hydra/memoizable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Hydra::Memoizable do

--- a/spec/typhoeus/hydra/queueable_spec.rb
+++ b/spec/typhoeus/hydra/queueable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Hydra::Queueable do

--- a/spec/typhoeus/hydra/runnable_spec.rb
+++ b/spec/typhoeus/hydra/runnable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Hydra::Runnable do

--- a/spec/typhoeus/hydra/stubbable_spec.rb
+++ b/spec/typhoeus/hydra/stubbable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Hydra::Stubbable do

--- a/spec/typhoeus/hydra_spec.rb
+++ b/spec/typhoeus/hydra_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe Typhoeus::Hydra do

--- a/spec/typhoeus/pool_spec.rb
+++ b/spec/typhoeus/pool_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Pool do

--- a/spec/typhoeus/request/actions_spec.rb
+++ b/spec/typhoeus/request/actions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Request::Actions do

--- a/spec/typhoeus/request/before_spec.rb
+++ b/spec/typhoeus/request/before_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Request::Before do

--- a/spec/typhoeus/request/block_connection_spec.rb
+++ b/spec/typhoeus/request/block_connection_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Request::BlockConnection do

--- a/spec/typhoeus/request/cacheable_spec.rb
+++ b/spec/typhoeus/request/cacheable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Request::Cacheable do

--- a/spec/typhoeus/request/callbacks_spec.rb
+++ b/spec/typhoeus/request/callbacks_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Request::Callbacks do

--- a/spec/typhoeus/request/marshal_spec.rb
+++ b/spec/typhoeus/request/marshal_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Request::Marshal do

--- a/spec/typhoeus/request/memoizable_spec.rb
+++ b/spec/typhoeus/request/memoizable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Request::Memoizable do

--- a/spec/typhoeus/request/operations_spec.rb
+++ b/spec/typhoeus/request/operations_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Request::Operations do

--- a/spec/typhoeus/request/responseable_spec.rb
+++ b/spec/typhoeus/request/responseable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Request::Responseable do

--- a/spec/typhoeus/request/stubbable_spec.rb
+++ b/spec/typhoeus/request/stubbable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Request::Stubbable do

--- a/spec/typhoeus/request_spec.rb
+++ b/spec/typhoeus/request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Request do

--- a/spec/typhoeus/response/header_spec.rb
+++ b/spec/typhoeus/response/header_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Response::Header do

--- a/spec/typhoeus/response/informations_spec.rb
+++ b/spec/typhoeus/response/informations_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Response::Informations do

--- a/spec/typhoeus/response/status_spec.rb
+++ b/spec/typhoeus/response/status_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Response::Status do

--- a/spec/typhoeus/response_spec.rb
+++ b/spec/typhoeus/response_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus::Response do

--- a/spec/typhoeus_spec.rb
+++ b/spec/typhoeus_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Typhoeus do

--- a/typhoeus.gemspec
+++ b/typhoeus.gemspec
@@ -1,4 +1,5 @@
-# encoding: utf-8
+# frozen_string_literal: true
+
 lib = File.expand_path('../lib/', __FILE__)
 $:.unshift lib unless $:.include?(lib)
 


### PR DESCRIPTION
```
rubocop --only Style/Encoding,Style/FrozenStringLiteralComment,Layout/EmptyLineAfterMagicComment,Style/RedundantFreeze -A
```

Ref: https://gist.github.com/fxn/bf4eed2505c76f4fca03ab48c43adc72