### PR TITLE
Bump ethon upper bound from < 0.16.0 to < 0.19.0

### DIFF
--- a/typhoeus.gemspec
+++ b/typhoeus.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
     'source_code_uri'       => "https://github.com/typhoeus/typhoeus/tree/v#{s.version}"
   }
 
-  s.add_dependency('ethon', [">= 0.9.0", "< 0.16.0"])
+  s.add_dependency('ethon', [">= 0.9.0", "< 0.19.0"])
 
   s.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |file|


### PR DESCRIPTION
The ethon dependency was pinned to < 0.16.0 which prevents using ethon 0.18.0. This relaxes the upper bound to allow 0.18.x releases.

Full test suite passed in local builds:

```
bundle && bundle exec rake
...
Finished in 0.18836 seconds (files took 0.34655 seconds to load)
  460 examples, 0 failures, 1 pending
```